### PR TITLE
Add LocaleMiddleware to make Django admin localized

### DIFF
--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -110,6 +110,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
As we have some translations issues with administrative divisions,
it would be handy to be able to switch languages in admin panel.