### PR TITLE
Add model change logging

### DIFF
--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -104,6 +104,7 @@ INSTALLED_APPS = [
     "munigeo",
     "users",
     "profiles",
+    "reversion",
 ]
 
 MIDDLEWARE = [
@@ -116,6 +117,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "reversion.middleware.RevisionMiddleware",
 ]
 
 TEMPLATES = [

--- a/profiles/api.py
+++ b/profiles/api.py
@@ -96,7 +96,7 @@ class ProfileViewSet(viewsets.ModelViewSet):
     renderer_classes = [JSONRenderer, BrowsableAPIRenderer]
 
     def get_queryset(self):
-        if self.request.user.is_staff:
+        if self.request.user.is_superuser:
             return self.queryset
         return self.queryset.filter(user=self.request.user)
 

--- a/profiles/api.py
+++ b/profiles/api.py
@@ -96,6 +96,8 @@ class ProfileViewSet(viewsets.ModelViewSet):
     renderer_classes = [JSONRenderer, BrowsableAPIRenderer]
 
     def get_queryset(self):
+        if self.request.user.is_staff:
+            return self.queryset
         return self.queryset.filter(user=self.request.user)
 
     def perform_create(self, serializer):

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+import reversion
+
 
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
@@ -28,6 +30,7 @@ class OverwriteStorage(FileSystemStorage):
         return name
 
 
+@reversion.register()
 class Profile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     nickname = models.CharField(max_length=32, null=True, blank=True)
@@ -50,6 +53,9 @@ class Profile(models.Model):
     concepts_of_interest = models.ManyToManyField(Concept, blank=True)
     divisions_of_interest = models.ManyToManyField(AdministrativeDivision, blank=True)
     preferences = JSONField(null=True, blank=True)
+
+    def __str__(self):
+        return "{} {} ({})".format(self.user.first_name, self.user.last_name, self.user.uuid)
 
 
 class DivisionOfInterest(models.Model):

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -1,8 +1,7 @@
 import os
 import shutil
+
 import reversion
-
-
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.core.files.storage import FileSystemStorage
@@ -55,7 +54,9 @@ class Profile(models.Model):
     preferences = JSONField(null=True, blank=True)
 
     def __str__(self):
-        return "{} {} ({})".format(self.user.first_name, self.user.last_name, self.user.uuid)
+        return "{} {} ({})".format(
+            self.user.first_name, self.user.last_name, self.user.uuid
+        )
 
 
 class DivisionOfInterest(models.Model):

--- a/profiles/tests/conftest.py
+++ b/profiles/tests/conftest.py
@@ -7,6 +7,7 @@ from profiles.tests.factories import (
     ConceptFactory,
     ProfileFactory,
     UserFactory,
+    StaffUserFactory,
     VocabularyFactory,
 )
 from profiles.tests.utils import create_in_memory_image_file
@@ -43,6 +44,19 @@ def user_api_client(user):
 @pytest.fixture
 def user():
     return UserFactory()
+
+
+@pytest.fixture
+def staff_api_client(staff_user):
+    api_client = APIClient()
+    api_client.force_authenticate(user=staff_user)
+    api_client.user = staff_user
+    return api_client
+
+
+@pytest.fixture
+def staff_user():
+    return StaffUserFactory()
 
 
 @pytest.fixture

--- a/profiles/tests/conftest.py
+++ b/profiles/tests/conftest.py
@@ -6,7 +6,7 @@ from rest_framework.test import APIClient
 from profiles.tests.factories import (
     ConceptFactory,
     ProfileFactory,
-    StaffUserFactory,
+    SuperuserFactory,
     UserFactory,
     VocabularyFactory,
 )
@@ -47,16 +47,16 @@ def user():
 
 
 @pytest.fixture
-def staff_api_client(staff_user):
+def superuser_api_client(superuser):
     api_client = APIClient()
-    api_client.force_authenticate(user=staff_user)
-    api_client.user = staff_user
+    api_client.force_authenticate(user=superuser)
+    api_client.user = superuser
     return api_client
 
 
 @pytest.fixture
-def staff_user():
-    return StaffUserFactory()
+def superuser():
+    return SuperuserFactory()
 
 
 @pytest.fixture

--- a/profiles/tests/conftest.py
+++ b/profiles/tests/conftest.py
@@ -6,8 +6,8 @@ from rest_framework.test import APIClient
 from profiles.tests.factories import (
     ConceptFactory,
     ProfileFactory,
-    UserFactory,
     StaffUserFactory,
+    UserFactory,
     VocabularyFactory,
 )
 from profiles.tests.utils import create_in_memory_image_file

--- a/profiles/tests/factories.py
+++ b/profiles/tests/factories.py
@@ -17,8 +17,8 @@ class UserFactory(factory.django.DjangoModelFactory):
         model = User
 
 
-class StaffUserFactory(UserFactory):
-    is_staff = True
+class SuperuserFactory(UserFactory):
+    is_superuser = True
 
     class Meta:
         model = User

--- a/profiles/tests/factories.py
+++ b/profiles/tests/factories.py
@@ -17,6 +17,13 @@ class UserFactory(factory.django.DjangoModelFactory):
         model = User
 
 
+class StaffUserFactory(UserFactory):
+    is_staff = True
+
+    class Meta:
+        model = User
+
+
 class ProfileFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
 

--- a/profiles/tests/test_profiles_api.py
+++ b/profiles/tests/test_profiles_api.py
@@ -1,13 +1,13 @@
 import os
 import tempfile
-import reversion
 
+import reversion
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.utils import override_settings
 from rest_framework.reverse import reverse
-from thesaurus.models import Concept
 from reversion.models import Version
+from thesaurus.models import Concept
 
 from profiles.models import get_user_media_folder, Profile
 from profiles.tests.factories import ProfileFactory
@@ -45,7 +45,7 @@ def test_user_can_see_only_own_profile(user_api_client, profile):
 
 def test_staff_can_view_all_profiles(staff_api_client):
     a_user_profile = ProfileFactory()
-    other_user_profile = ProfileFactory()
+    other_user_profile = ProfileFactory()  # noqa
 
     data = get(staff_api_client, PROFILE_URL)
     results = data["results"]
@@ -256,7 +256,9 @@ def test_update_own_profile_creates_change_log_entry(user_api_client):
     assert versions[0].field_dict["email"] == email_data["email"]
 
 
-def test_admin_update_profile_creates_change_log_entry(user_api_client, staff_api_client):
+def test_admin_update_profile_creates_change_log_entry(
+    user_api_client, staff_api_client
+):
     with reversion.create_revision():
         post_create(user_api_client, PROFILE_URL)
 

--- a/profiles/tests/test_profiles_api.py
+++ b/profiles/tests/test_profiles_api.py
@@ -1,11 +1,13 @@
 import os
 import tempfile
+import reversion
 
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.utils import override_settings
 from rest_framework.reverse import reverse
 from thesaurus.models import Concept
+from reversion.models import Version
 
 from profiles.models import get_user_media_folder, Profile
 from profiles.tests.factories import ProfileFactory
@@ -41,7 +43,18 @@ def test_user_can_see_only_own_profile(user_api_client, profile):
     get(user_api_client, get_user_profile_url(other_user_profile), status_code=404)
 
 
-def test_post_create_profile(user_api_client):
+def test_staff_can_view_all_profiles(staff_api_client):
+    a_user_profile = ProfileFactory()
+    other_user_profile = ProfileFactory()
+
+    data = get(staff_api_client, PROFILE_URL)
+    results = data["results"]
+    assert len(results) == 2
+
+    get(staff_api_client, get_user_profile_url(a_user_profile), status_code=200)
+
+
+def test_post_create_own_profile(user_api_client):
     assert Profile.objects.count() == 0
 
     post_create(user_api_client, PROFILE_URL)
@@ -88,6 +101,16 @@ def test_put_update_own_profile(user_api_client, profile):
 
     profile.refresh_from_db()
     assert profile.phone == phone_number_data["phone"]
+
+
+def test_staff_can_update_profile(staff_api_client, profile):
+    new_email_data = {"email": "new.email@provider.com"}
+    assert profile.email != new_email_data["email"]
+
+    put_update(staff_api_client, get_user_profile_url(profile), new_email_data)
+    profile.refresh_from_db()
+    assert profile.email == new_email_data["email"]
+    assert profile.user != staff_api_client.user
 
 
 def test_expected_profile_data_fields(user_api_client, profile):
@@ -212,3 +235,41 @@ def test_put_concept_of_interest_in_wrong_format(user_api_client, profile, conce
     put_update(
         user_api_client, user_profile_url, concept_of_interest_data, status_code=400
     )
+
+
+def test_update_own_profile_creates_change_log_entry(user_api_client):
+    with reversion.create_revision():
+        post_create(user_api_client, PROFILE_URL)
+
+    profile = Profile.objects.latest("id")
+    versions = Version.objects.get_for_object(profile)
+    assert len(versions) == 1
+
+    user_profile_url = get_user_profile_url(profile)
+    email_data = {"email": "new.email@provider.com"}
+    put_update(user_api_client, user_profile_url, email_data)
+
+    profile.refresh_from_db()
+    versions = Version.objects.get_for_object(profile)
+    assert len(versions) == 2
+    assert versions[0].revision.user == user_api_client.user
+    assert versions[0].field_dict["email"] == email_data["email"]
+
+
+def test_admin_update_profile_creates_change_log_entry(user_api_client, staff_api_client):
+    with reversion.create_revision():
+        post_create(user_api_client, PROFILE_URL)
+
+    profile = Profile.objects.latest("id")
+    versions = Version.objects.get_for_object(profile)
+    assert len(versions) == 1
+    assert versions[0].revision.user == user_api_client.user
+
+    user_profile_url = get_user_profile_url(profile)
+    email_data = {"email": "new.email@provider.com"}
+    put_update(staff_api_client, user_profile_url, email_data)
+
+    profile.refresh_from_db()
+    versions = Version.objects.get_for_object(profile)
+    assert len(versions) == 2
+    assert versions[0].revision.user == staff_api_client.user

--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ django-parler-rest
 django-munigeo
 pillow
 sentry-sdk
+django-reversion

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ django-mptt==0.10.0       # via django-munigeo
 django-munigeo==0.3.3
 django-parler-rest==2.0
 django-parler==1.9.2      # via django-munigeo, django-parler-rest, django-thesaurus
+django-reversion==3.0.4
 django-thesaurus==0.0.2
 django==2.2.3
 djangorestframework==3.10.1

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from reversion.admin import VersionAdmin
 
 from profiles.admin import ProfileAdmin
 
@@ -7,7 +8,7 @@ User = get_user_model()
 
 
 @admin.register(User)
-class ExtendedUserAdmin(admin.ModelAdmin):
+class ExtendedUserAdmin(VersionAdmin):
     inlines = [ProfileAdmin]
 
     def get_readonly_fields(self, request, obj=None):

--- a/users/models.py
+++ b/users/models.py
@@ -1,5 +1,4 @@
 import reversion
-
 from helusers.models import AbstractUser
 
 

--- a/users/models.py
+++ b/users/models.py
@@ -1,5 +1,8 @@
+import reversion
+
 from helusers.models import AbstractUser
 
 
+@reversion.register()
 class User(AbstractUser):
     pass


### PR DESCRIPTION
REFS KUVA-183

This PR adds model instance change logging with `django-reversion`, which saves versions of serialized model instances in a separate table along with the user of the request. We use the middleware provided to automatically mark changes inside requests (excluding GET, HEAD, and OPTIONS) as belonging to a new revision.

`django-reversion` also provides admin integration for viewing, reverting to previous versions, and restoring deleted models.
![image](https://user-images.githubusercontent.com/5655648/62455609-75682580-b77f-11e9-8929-130458c5f136.png)

New models must be marked for logging with `@reversion.register()` and bootstrapped with `createinitialrevisions` admin command.

NB! `django-reversion` works by detecting the signals fired by `save()`, so **bulk actions such as `Queryset.update()` won't be saved!**