### PR TITLE
Update django ilmoitin

### DIFF
--- a/profiles/notifications.py
+++ b/profiles/notifications.py
@@ -1,3 +1,4 @@
+from django_ilmoitin.dummy_context import dummy_context
 from django_ilmoitin.registry import notifications
 
 from .enums import NotificationType
@@ -10,3 +11,5 @@ notifications.register(
     NotificationType.RELATIONSHIP_CONFIRMED.value,
     NotificationType.RELATIONSHIP_CONFIRMED.label,
 )
+
+dummy_context.context.update({"relationship": None})

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ django-enumfields==1.0.0  # via django-ilmoitin
 django-environ==0.4.5
 django-filter==2.2.0
 django-helusers==0.4.5
-django-ilmoitin==0.1.2
+django-ilmoitin==0.1.3
 django-js-asset==1.2.2    # via django-mptt
 django-mailer==1.2.6      # via django-ilmoitin
 django-mptt==0.10.0       # via django-munigeo


### PR DESCRIPTION
Refs KUVA-199

Update to the newest `django-ilmoitin` version available - 0.1.3 - on PyPI.

Also add a `dummy_context` so that previewing the notification templates doesn't throw an exception.