### PR TITLE
Fix helusers GraphQL auth wrapper

### DIFF
--- a/open_city_profile/oidc.py
+++ b/open_city_profile/oidc.py
@@ -13,5 +13,8 @@ class GraphQLApiTokenAuthentication(ApiTokenAuthentication):
     """
 
     def authenticate(self, request, **kwargs):
-        user, auth = super().authenticate(request)
+        user_auth_tuple = super().authenticate(request)
+        if not user_auth_tuple:
+            return None
+        user, auth = user_auth_tuple
         return user


### PR DESCRIPTION
If the user could not be authenticated with the helusers,
calling `super().authenticate()` will return `None`.
Check for this case, before going further with the auth.