### PR TITLE
OM-255 | Configure database seeding during deployment

### DIFF
--- a/.prod/on_deploy.sh
+++ b/.prod/on_deploy.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-python /app/manage.py geo_import finland --municipalities
-python /app/manage.py geo_import helsinki --divisions
-python /app/manage.py mark_divisions_of_interest
 python /app/manage.py migrate --noinput
+python /app/manage.py seed_data


### PR DESCRIPTION
The CI build executes on_deploy.sh during deployment to initialize the db.
I added a command for running the data seeding script to get the database
set up with users, profiles etc. I also removed the scripts for creating
municipalities etc, because we're not currently doing anything with those.