### PR TITLE
OM-295 | Add id argument to mutations

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -92,7 +92,11 @@ def update_profile(info, profile, profile_data):
 
     if youth_profile_data:
         if "id" in youth_profile_data:
-            UpdateYouthProfile().mutate(info, youth_profile=youth_profile_data)
+            UpdateYouthProfile().mutate(
+                info,
+                youth_profile=youth_profile_data,
+                profile_id=to_global_id(type="Profile", id=profile.id),
+            )
         else:
             CreateYouthProfile().mutate(
                 info,

--- a/profiles/tests/test_profiles_graphql_api.py
+++ b/profiles/tests/test_profiles_graphql_api.py
@@ -100,6 +100,7 @@ def test_normal_user_can_update_profile(rf, user_gql_client, email_data, profile
             mutation {
                 updateProfile(
                     profile: {
+                        id: \"${profile_id}\",
                         nickname: \"${nickname}\",
                         updateEmails:[
                             {
@@ -150,6 +151,7 @@ def test_normal_user_can_update_profile(rf, user_gql_client, email_data, profile
     }
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         nickname=profile_data["nickname"],
         email_id=to_global_id(type="EmailNode", id=email.id),
         email=email_data["email"],
@@ -157,11 +159,12 @@ def test_normal_user_can_update_profile(rf, user_gql_client, email_data, profile
         primary=str(email_data["primary"]).lower(),
     )
     executed = user_gql_client.execute(mutation, context=request)
+    assert "errors" not in executed
     assert dict(executed["data"]) == expected_data
 
 
 def test_normal_user_can_add_email(rf, user_gql_client, email_data):
-    ProfileFactory(user=user_gql_client.user)
+    profile = ProfileFactory(user=user_gql_client.user)
     request = rf.post("/graphql")
     request.user = user_gql_client.user
 
@@ -170,6 +173,7 @@ def test_normal_user_can_add_email(rf, user_gql_client, email_data):
             mutation {
                 updateProfile(
                     profile: {
+                    id: \"${profile_id}\",
                     addEmails:[
                         {emailType: ${email_type}, email:\"${email}\", primary: ${primary}}
                     ]
@@ -210,6 +214,7 @@ def test_normal_user_can_add_email(rf, user_gql_client, email_data):
     }
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         email=email_data["email"],
         email_type=email_data["email_type"],
         primary=str(email_data["primary"]).lower(),
@@ -219,7 +224,7 @@ def test_normal_user_can_add_email(rf, user_gql_client, email_data):
 
 
 def test_normal_user_can_add_phone(rf, user_gql_client, phone_data):
-    ProfileFactory(user=user_gql_client.user)
+    profile = ProfileFactory(user=user_gql_client.user)
     request = rf.post("/graphql")
     request.user = user_gql_client.user
 
@@ -228,6 +233,7 @@ def test_normal_user_can_add_phone(rf, user_gql_client, phone_data):
             mutation {
                 updateProfile(
                     profile: {
+                    id: \"${profile_id}\",
                     addPhones:[
                         {phoneType: ${phone_type}, phone:\"${phone}\", primary: ${primary}}
                     ]
@@ -268,6 +274,7 @@ def test_normal_user_can_add_phone(rf, user_gql_client, phone_data):
     }
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         phone=phone_data["phone"],
         phone_type=phone_data["phone_type"],
         primary=str(phone_data["primary"]).lower(),
@@ -277,7 +284,7 @@ def test_normal_user_can_add_phone(rf, user_gql_client, phone_data):
 
 
 def test_normal_user_can_add_address(rf, user_gql_client, address_data):
-    ProfileFactory(user=user_gql_client.user)
+    profile = ProfileFactory(user=user_gql_client.user)
     request = rf.post("/graphql")
     request.user = user_gql_client.user
 
@@ -286,6 +293,7 @@ def test_normal_user_can_add_address(rf, user_gql_client, address_data):
             mutation {
                 updateProfile(
                     profile: {
+                    id: \"${profile_id}\",
                     addAddresses:[
                         {
                             addressType: ${address_type},
@@ -339,6 +347,7 @@ def test_normal_user_can_add_address(rf, user_gql_client, address_data):
     }
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         address=address_data["address"],
         postal_code=address_data["postal_code"],
         city=address_data["city"],
@@ -361,6 +370,7 @@ def test_normal_user_can_update_address(rf, user_gql_client, address_data):
             mutation {
                 updateProfile(
                     profile: {
+                    id: \"${profile_id}\",
                     updateAddresses:[
                         {
                             id: \"${address_id}\",
@@ -414,6 +424,7 @@ def test_normal_user_can_update_address(rf, user_gql_client, address_data):
     }
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         address_id=to_global_id(type="AddressNode", id=address.id),
         address=address_data["address"],
         postal_code=address_data["postal_code"],
@@ -436,6 +447,7 @@ def test_normal_user_can_update_email(rf, user_gql_client, email_data):
             mutation {
                 updateProfile(
                     profile: {
+                    id: \"${profile_id}\",
                     updateEmails:[
                         {
                             id: \"${email_id}\",
@@ -483,6 +495,7 @@ def test_normal_user_can_update_email(rf, user_gql_client, email_data):
     }
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         email_id=to_global_id(type="EmailNode", id=email.id),
         email=email_data["email"],
         email_type=email_data["email_type"],
@@ -503,6 +516,7 @@ def test_normal_user_can_update_phone(rf, user_gql_client, phone_data):
             mutation {
                 updateProfile(
                     profile: {
+                    id: \"${profile_id}\",
                     updatePhones:[
                         {
                             id: \"${phone_id}\",
@@ -550,6 +564,7 @@ def test_normal_user_can_update_phone(rf, user_gql_client, phone_data):
     }
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         phone_id=to_global_id(type="PhoneNode", id=phone.id),
         phone=phone_data["phone"],
         phone_type=phone_data["phone_type"],
@@ -570,10 +585,11 @@ def test_normal_user_can_remove_email(rf, user_gql_client, email_data):
             mutation {
                 updateProfile(
                     profile: {
+                    id: \"${profile_id}\",
                     removeEmails:[
                         \"${email_id}\"
                     ]
-                }
+                    }
             ) {
                 profile{
                     emails{
@@ -595,6 +611,7 @@ def test_normal_user_can_remove_email(rf, user_gql_client, email_data):
     expected_data = {"updateProfile": {"profile": {"emails": {"edges": []}}}}
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         email_id=to_global_id(type="EmailNode", id=email.id),
         email=email_data["email"],
         email_type=email_data["email_type"],
@@ -615,6 +632,7 @@ def test_normal_user_can_remove_phone(rf, user_gql_client, phone_data):
             mutation {
                 updateProfile(
                     profile: {
+                    id: \"${profile_id}\",
                     removePhones:[
                         \"${phone_id}\"
                     ]
@@ -640,6 +658,7 @@ def test_normal_user_can_remove_phone(rf, user_gql_client, phone_data):
     expected_data = {"updateProfile": {"profile": {"phones": {"edges": []}}}}
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         phone_id=to_global_id(type="PhoneNode", id=phone.id),
         phone=phone_data["phone"],
         phone_type=phone_data["phone_type"],
@@ -660,6 +679,7 @@ def test_normal_user_can_remove_address(rf, user_gql_client, address_data):
             mutation {
                 updateProfile(
                     profile: {
+                    id: \"${profile_id}\",
                     removeAddresses:[
                         \"${address_id}\"
                     ]
@@ -685,6 +705,7 @@ def test_normal_user_can_remove_address(rf, user_gql_client, address_data):
     expected_data = {"updateProfile": {"profile": {"addresses": {"edges": []}}}}
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         address_id=to_global_id(type="AddressNode", id=address.id),
         address=address_data["address"],
         address_type=address_data["address_type"],
@@ -880,6 +901,7 @@ def test_normal_user_can_change_primary_contact_details(
             mutation {
                 updateProfile(
                     profile: {
+                        id: \"${profile_id}\"
                         addEmails:[
                             {emailType: ${email_type}, email:\"${email}\", primary: ${primary}}
                         ],
@@ -946,6 +968,7 @@ def test_normal_user_can_change_primary_contact_details(
     }
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         email=email_data["email"],
         email_type=email_data["email_type"],
         phone=phone_data["phone"],
@@ -974,6 +997,7 @@ def test_normal_user_can_update_primary_contact_details(
             mutation {
                 updateProfile(
                     profile: {
+                    id: \"${profile_id}\"
                     updateEmails:[
                         {
                             id: \"${email_id}\",
@@ -1029,6 +1053,7 @@ def test_normal_user_can_update_primary_contact_details(
     }
 
     mutation = t.substitute(
+        profile_id=to_global_id(type="ProfileNode", id=profile.id),
         email_id=to_global_id(type="EmailNode", id=email.id),
         email=email_data["email"],
         email_type=email_data["email_type"],

--- a/youths/tests/test_youth_profiles_graphql_api.py
+++ b/youths/tests/test_youth_profiles_graphql_api.py
@@ -1,6 +1,8 @@
 import uuid
 from string import Template
 
+from graphql_relay.node.node import to_global_id
+
 from youths.enums import YouthLanguage
 from youths.tests.factories import ProfileFactory, YouthProfileFactory
 
@@ -282,6 +284,7 @@ def test_normal_user_can_update_youth_profile__through_my_profile_mutation(
             mutation {
                 updateProfile(
                     profile: {
+                        id: \"${profileId}\",
                         nickname: \"${nickname}\",
                         youthProfile: {
                             schoolClass: "${schoolClass}"
@@ -303,6 +306,7 @@ def test_normal_user_can_update_youth_profile__through_my_profile_mutation(
     )
 
     creation_data = {
+        "profileId": to_global_id(type="ProfileNode", id=profile.id),
         "nickname": "Larry",
         "schoolClass": "2A",
         "birthDate": "2002-02-02",


### PR DESCRIPTION
The purpose of this is to have more generic support for nested mutations
(and to get rid of dependencies where we query `Profile` or `YouthProfile`
via `info.context.user`) where we give youth profile data inside profile data. 
This will enable smoother reuse of the same mutations for administrative
use. We should be able to support following mutations:

- Create new profile and create new youth profile
- Update profile and create new youth profile
- Update profile and update youth profile

In order to accomplish this, following changes have been made:

- Add `id` argument to `updateProfile`
- Add `id` and `profile_id` arguments to `updateYouthProfile`
- Fix `updateProfile` to call correct youth mutation depending on arguments
- Fix permissions
- Fix tests and write additional tests