### PR TITLE
OM-337 | My mutations

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1,5 +1,6 @@
 import graphene
 from django.conf import settings
+from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import override
 from django_filters import CharFilter, FilterSet, OrderingFilter
@@ -263,6 +264,7 @@ class CreateMyProfile(graphene.Mutation):
     profile = graphene.Field(ProfileNode)
 
     @login_required
+    @transaction.atomic
     def mutate(self, info, **kwargs):
         profile_data = kwargs.pop("profile")
         youth_profile_data = profile_data.pop("youth_profile", None)
@@ -293,6 +295,7 @@ class UpdateMyProfile(graphene.Mutation):
     profile = graphene.Field(ProfileNode)
 
     @login_required
+    @transaction.atomic
     def mutate(self, info, **kwargs):
         profile_data = kwargs.pop("profile")
         youth_profile_data = profile_data.pop("youth_profile", None)
@@ -336,6 +339,7 @@ class DeleteMyProfile(graphene.Mutation):
     ok = graphene.Boolean()
 
     @login_required
+    @transaction.atomic
     def mutate(self, info, **kwargs):
         try:
             profile = Profile.objects.get(user=info.context.user)

--- a/profiles/tests/test_profiles_graphql_api.py
+++ b/profiles/tests/test_profiles_graphql_api.py
@@ -35,11 +35,13 @@ def test_normal_user_can_create_profile(rf, user_gql_client, email_data, profile
         """
             mutation {
                 createMyProfile(
-                    profile: {
-                        nickname: \"${nickname}\",
-                        addEmails:[
-                            {emailType: ${email_type}, email:\"${email}\", primary: ${primary}}
-                        ]
+                    input: {
+                        profile: {
+                            nickname: \"${nickname}\",
+                            addEmails:[
+                                {emailType: ${email_type}, email:\"${email}\", primary: ${primary}}
+                            ]
+                        }
                     }
                 ) {
                 profile{
@@ -98,16 +100,18 @@ def test_normal_user_can_update_profile(rf, user_gql_client, email_data, profile
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                        nickname: \"${nickname}\",
-                        updateEmails:[
-                            {
-                                id: \"${email_id}\",
-                                emailType: ${email_type},
-                                email:\"${email}\",
-                                primary: ${primary}
-                            }
-                        ]
+                    input: {
+                        profile: {
+                            nickname: \"${nickname}\",
+                            updateEmails:[
+                                {
+                                    id: \"${email_id}\",
+                                    emailType: ${email_type},
+                                    email:\"${email}\",
+                                    primary: ${primary}
+                                }
+                            ]
+                        }
                     }
                 ) {
                     profile{
@@ -168,11 +172,13 @@ def test_normal_user_can_add_email(rf, user_gql_client, email_data):
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                    addEmails:[
-                        {emailType: ${email_type}, email:\"${email}\", primary: ${primary}}
-                    ]
-                }
+                    input: {
+                        profile: {
+                            addEmails:[
+                                {emailType: ${email_type}, email:\"${email}\", primary: ${primary}}
+                            ]
+                        }
+                    }
             ) {
                 profile{
                     emails{
@@ -226,10 +232,12 @@ def test_normal_user_can_add_phone(rf, user_gql_client, phone_data):
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                    addPhones:[
-                        {phoneType: ${phone_type}, phone:\"${phone}\", primary: ${primary}}
-                    ]
+                    input: {
+                        profile: {
+                        addPhones:[
+                            {phoneType: ${phone_type}, phone:\"${phone}\", primary: ${primary}}
+                        ]
+                    }
                 }
             ) {
                 profile{
@@ -284,30 +292,32 @@ def test_normal_user_can_add_address(rf, user_gql_client, address_data):
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                    addAddresses:[
-                        {
-                            addressType: ${address_type},
-                            address:\"${address}\",
-                            postalCode: \"${postal_code}\",
-                            city: \"${city}\",
-                            countryCode: \"${country_code}\",
-                            primary: ${primary}
+                    input: {
+                        profile: {
+                            addAddresses: [
+                                {
+                                    addressType: ${address_type},
+                                    address:\"${address}\",
+                                    postalCode: \"${postal_code}\",
+                                    city: \"${city}\",
+                                    countryCode: \"${country_code}\",
+                                    primary: ${primary}
+                                }
+                            ]
                         }
-                    ]
-                }
-            ) {
-                profile{
-                    addresses{
-                        edges{
-                        node{
-                            address
-                            postalCode
-                            city
-                            countryCode
-                            addressType
-                            primary
-                        }
+                    }
+                ) {
+                profile {
+                    addresses {
+                        edges {
+                            node {
+                                address
+                                postalCode
+                                city
+                                countryCode
+                                addressType
+                                primary
+                            }
                         }
                     }
                 }
@@ -359,17 +369,19 @@ def test_normal_user_can_update_address(rf, user_gql_client, address_data):
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                    updateAddresses:[
-                        {
-                            id: \"${address_id}\",
-                            addressType: ${address_type},
-                            address:\"${address}\",
-                            postalCode:\"${postal_code}\",
-                            city:\"${city}\",
-                            primary: ${primary}
-                        }
-                    ]
+                    input: {
+                        profile: {
+                        updateAddresses:[
+                            {
+                                id: \"${address_id}\",
+                                addressType: ${address_type},
+                                address:\"${address}\",
+                                postalCode:\"${postal_code}\",
+                                city:\"${city}\",
+                                primary: ${primary}
+                            }
+                        ]
+                    }
                 }
             ) {
                 profile{
@@ -434,15 +446,17 @@ def test_normal_user_can_update_email(rf, user_gql_client, email_data):
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                    updateEmails:[
-                        {
-                            id: \"${email_id}\",
-                            emailType: ${email_type},
-                            email:\"${email}\",
-                            primary: ${primary}
-                        }
-                    ]
+                    input: {
+                        profile: {
+                        updateEmails:[
+                            {
+                                id: \"${email_id}\",
+                                emailType: ${email_type},
+                                email:\"${email}\",
+                                primary: ${primary}
+                            }
+                        ]
+                    }
                 }
             ) {
                 profile{
@@ -501,15 +515,17 @@ def test_normal_user_can_update_phone(rf, user_gql_client, phone_data):
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                    updatePhones:[
-                        {
-                            id: \"${phone_id}\",
-                            phoneType: ${phone_type},
-                            phone:\"${phone}\",
-                            primary: ${primary}
-                        }
-                    ]
+                    input: {
+                        profile: {
+                        updatePhones:[
+                            {
+                                id: \"${phone_id}\",
+                                phoneType: ${phone_type},
+                                phone:\"${phone}\",
+                                primary: ${primary}
+                            }
+                        ]
+                    }
                 }
             ) {
                 profile{
@@ -568,10 +584,12 @@ def test_normal_user_can_remove_email(rf, user_gql_client, email_data):
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                    removeEmails:[
-                        \"${email_id}\"
-                    ]
+                    input: {
+                        profile: {
+                        removeEmails:[
+                            \"${email_id}\"
+                        ]
+                    }
                 }
             ) {
                 profile{
@@ -613,10 +631,12 @@ def test_normal_user_can_remove_phone(rf, user_gql_client, phone_data):
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                    removePhones:[
-                        \"${phone_id}\"
-                    ]
+                    input: {
+                        profile: {
+                        removePhones:[
+                            \"${phone_id}\"
+                        ]
+                    }
                 }
             ) {
                 profile{
@@ -658,10 +678,12 @@ def test_normal_user_can_remove_address(rf, user_gql_client, address_data):
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                    removeAddresses:[
-                        \"${address_id}\"
-                    ]
+                    input: {
+                        profile: {
+                        removeAddresses:[
+                            \"${address_id}\"
+                        ]
+                    }
                 }
             ) {
                 profile{
@@ -878,22 +900,24 @@ def test_normal_user_can_change_primary_contact_details(
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                        addEmails:[
-                            {emailType: ${email_type}, email:\"${email}\", primary: ${primary}}
-                        ],
-                        addPhones:[
-                            {phoneType: ${phone_type}, phone:\"${phone}\", primary: ${primary}}
-                        ],
-                        addAddresses:[
-                            {
-                                addressType: ${address_type},
-                                address:\"${address}\",
-                                postalCode:\"${postal_code}\",
-                                city:\"${city}\",
-                                primary: ${primary}
-                            }
-                        ]
+                    input: {
+                        profile: {
+                            addEmails:[
+                                {emailType: ${email_type}, email:\"${email}\", primary: ${primary}}
+                            ],
+                            addPhones:[
+                                {phoneType: ${phone_type}, phone:\"${phone}\", primary: ${primary}}
+                            ],
+                            addAddresses:[
+                                {
+                                    addressType: ${address_type},
+                                    address:\"${address}\",
+                                    postalCode:\"${postal_code}\",
+                                    city:\"${city}\",
+                                    primary: ${primary}
+                                }
+                            ]
+                        }
                     }
                 ) {
                 profile{
@@ -972,15 +996,17 @@ def test_normal_user_can_update_primary_contact_details(
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                    updateEmails:[
-                        {
-                            id: \"${email_id}\",
-                            emailType: ${email_type},
-                            email:\"${email}\",
-                            primary: ${primary}
-                        }
-                    ]
+                    input: {
+                        profile: {
+                        updateEmails:[
+                            {
+                                id: \"${email_id}\",
+                                emailType: ${email_type},
+                                email:\"${email}\",
+                                primary: ${primary}
+                            }
+                        ]
+                    }
                 }
             ) {
                 profile{
@@ -1047,14 +1073,14 @@ def test_normal_user_can_delete_his_profile(rf, user_gql_client):
     t = Template(
         """
             mutation {
-                deleteMyProfile {
-                    ok
+                deleteMyProfile(input: {}) {
+                    clientMutationId
                 }
             }
         """
     )
 
-    expected_data = {"deleteMyProfile": {"ok": True}}
+    expected_data = {"deleteMyProfile": {"clientMutationId": None}}
 
     mutation = t.substitute(id=to_global_id(type="ProfileNode", id=profile.id))
     executed = user_gql_client.execute(mutation, context=request)
@@ -1073,8 +1099,8 @@ def test_normal_user_cannot_delete_his_profile_if_service_berth_connected(
     t = Template(
         """
             mutation {
-                deleteMyProfile {
-                    ok
+                deleteMyProfile(input: {}) {
+                    clientMutationId
                 }
             }
         """
@@ -1102,8 +1128,8 @@ def test_normal_user_gets_error_when_deleting_non_existent_profile(rf, user_gql_
     t = Template(
         """
             mutation {
-                deleteMyProfile {
-                    ok
+                deleteMyProfile(input: {}) {
+                    clientMutationId
                 }
             }
         """

--- a/profiles/tests/test_profiles_graphql_api.py
+++ b/profiles/tests/test_profiles_graphql_api.py
@@ -10,7 +10,6 @@ from guardian.shortcuts import assign_perm
 from open_city_profile.consts import (
     CANNOT_DELETE_PROFILE_WHILE_SERVICE_CONNECTED_ERROR,
     OBJECT_DOES_NOT_EXIST_ERROR,
-    PERMISSION_DENIED_ERROR,
     PROFILE_DOES_NOT_EXIST_ERROR,
     TOKEN_EXPIRED_ERROR,
 )
@@ -35,7 +34,7 @@ def test_normal_user_can_create_profile(rf, user_gql_client, email_data, profile
     t = Template(
         """
             mutation {
-                createProfile(
+                createMyProfile(
                     profile: {
                         nickname: \"${nickname}\",
                         addEmails:[
@@ -61,7 +60,7 @@ def test_normal_user_can_create_profile(rf, user_gql_client, email_data, profile
     )
 
     expected_data = {
-        "createProfile": {
+        "createMyProfile": {
             "profile": {
                 "nickname": profile_data["nickname"],
                 "emails": {
@@ -98,7 +97,7 @@ def test_normal_user_can_update_profile(rf, user_gql_client, email_data, profile
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                         nickname: \"${nickname}\",
                         updateEmails:[
@@ -130,7 +129,7 @@ def test_normal_user_can_update_profile(rf, user_gql_client, email_data, profile
     )
 
     expected_data = {
-        "updateProfile": {
+        "updateMyProfile": {
             "profile": {
                 "nickname": profile_data["nickname"],
                 "emails": {
@@ -168,7 +167,7 @@ def test_normal_user_can_add_email(rf, user_gql_client, email_data):
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                     addEmails:[
                         {emailType: ${email_type}, email:\"${email}\", primary: ${primary}}
@@ -192,7 +191,7 @@ def test_normal_user_can_add_email(rf, user_gql_client, email_data):
     )
 
     expected_data = {
-        "updateProfile": {
+        "updateMyProfile": {
             "profile": {
                 "emails": {
                     "edges": [
@@ -226,7 +225,7 @@ def test_normal_user_can_add_phone(rf, user_gql_client, phone_data):
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                     addPhones:[
                         {phoneType: ${phone_type}, phone:\"${phone}\", primary: ${primary}}
@@ -250,7 +249,7 @@ def test_normal_user_can_add_phone(rf, user_gql_client, phone_data):
     )
 
     expected_data = {
-        "updateProfile": {
+        "updateMyProfile": {
             "profile": {
                 "phones": {
                     "edges": [
@@ -284,7 +283,7 @@ def test_normal_user_can_add_address(rf, user_gql_client, address_data):
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                     addAddresses:[
                         {
@@ -318,7 +317,7 @@ def test_normal_user_can_add_address(rf, user_gql_client, address_data):
     )
 
     expected_data = {
-        "updateProfile": {
+        "updateMyProfile": {
             "profile": {
                 "addresses": {
                     "edges": [
@@ -359,7 +358,7 @@ def test_normal_user_can_update_address(rf, user_gql_client, address_data):
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                     updateAddresses:[
                         {
@@ -393,7 +392,7 @@ def test_normal_user_can_update_address(rf, user_gql_client, address_data):
     )
 
     expected_data = {
-        "updateProfile": {
+        "updateMyProfile": {
             "profile": {
                 "addresses": {
                     "edges": [
@@ -434,7 +433,7 @@ def test_normal_user_can_update_email(rf, user_gql_client, email_data):
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                     updateEmails:[
                         {
@@ -464,7 +463,7 @@ def test_normal_user_can_update_email(rf, user_gql_client, email_data):
     )
 
     expected_data = {
-        "updateProfile": {
+        "updateMyProfile": {
             "profile": {
                 "emails": {
                     "edges": [
@@ -501,7 +500,7 @@ def test_normal_user_can_update_phone(rf, user_gql_client, phone_data):
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                     updatePhones:[
                         {
@@ -531,7 +530,7 @@ def test_normal_user_can_update_phone(rf, user_gql_client, phone_data):
     )
 
     expected_data = {
-        "updateProfile": {
+        "updateMyProfile": {
             "profile": {
                 "phones": {
                     "edges": [
@@ -568,7 +567,7 @@ def test_normal_user_can_remove_email(rf, user_gql_client, email_data):
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                     removeEmails:[
                         \"${email_id}\"
@@ -592,7 +591,7 @@ def test_normal_user_can_remove_email(rf, user_gql_client, email_data):
         """
     )
 
-    expected_data = {"updateProfile": {"profile": {"emails": {"edges": []}}}}
+    expected_data = {"updateMyProfile": {"profile": {"emails": {"edges": []}}}}
 
     mutation = t.substitute(
         email_id=to_global_id(type="EmailNode", id=email.id),
@@ -613,7 +612,7 @@ def test_normal_user_can_remove_phone(rf, user_gql_client, phone_data):
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                     removePhones:[
                         \"${phone_id}\"
@@ -637,7 +636,7 @@ def test_normal_user_can_remove_phone(rf, user_gql_client, phone_data):
         """
     )
 
-    expected_data = {"updateProfile": {"profile": {"phones": {"edges": []}}}}
+    expected_data = {"updateMyProfile": {"profile": {"phones": {"edges": []}}}}
 
     mutation = t.substitute(
         phone_id=to_global_id(type="PhoneNode", id=phone.id),
@@ -658,7 +657,7 @@ def test_normal_user_can_remove_address(rf, user_gql_client, address_data):
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                     removeAddresses:[
                         \"${address_id}\"
@@ -682,7 +681,7 @@ def test_normal_user_can_remove_address(rf, user_gql_client, address_data):
         """
     )
 
-    expected_data = {"updateProfile": {"profile": {"addresses": {"edges": []}}}}
+    expected_data = {"updateMyProfile": {"profile": {"addresses": {"edges": []}}}}
 
     mutation = t.substitute(
         address_id=to_global_id(type="AddressNode", id=address.id),
@@ -878,7 +877,7 @@ def test_normal_user_can_change_primary_contact_details(
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                         addEmails:[
                             {emailType: ${email_type}, email:\"${email}\", primary: ${primary}}
@@ -922,7 +921,7 @@ def test_normal_user_can_change_primary_contact_details(
     )
 
     expected_data = {
-        "updateProfile": {
+        "updateMyProfile": {
             "profile": {
                 "primaryEmail": {
                     "email": email_data["email"],
@@ -972,7 +971,7 @@ def test_normal_user_can_update_primary_contact_details(
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                     updateEmails:[
                         {
@@ -1002,7 +1001,7 @@ def test_normal_user_can_update_primary_contact_details(
     )
 
     expected_data = {
-        "updateProfile": {
+        "updateMyProfile": {
             "profile": {
                 "emails": {
                     "edges": [
@@ -1048,46 +1047,18 @@ def test_normal_user_can_delete_his_profile(rf, user_gql_client):
     t = Template(
         """
             mutation {
-                deleteProfile(
-                    id: \"${id}\",
-                ) {
+                deleteMyProfile {
                     ok
                 }
             }
         """
     )
 
-    expected_data = {"deleteProfile": {"ok": True}}
+    expected_data = {"deleteMyProfile": {"ok": True}}
 
     mutation = t.substitute(id=to_global_id(type="ProfileNode", id=profile.id))
     executed = user_gql_client.execute(mutation, context=request)
     assert dict(executed["data"]) == expected_data
-
-
-def test_no_user_cannot_delete_other_users_profile(rf, superuser_gql_client):
-    profile = ProfileFactory()
-    request = rf.post("/graphql")
-    request.user = superuser_gql_client.user
-
-    t = Template(
-        """
-            mutation {
-                deleteProfile(
-                    id: \"${id}\",
-                ) {
-                    ok
-                }
-            }
-        """
-    )
-
-    expected_data = {"deleteProfile": None}
-
-    mutation = t.substitute(id=to_global_id(type="ProfileNode", id=profile.id))
-    executed = superuser_gql_client.execute(mutation, context=request)
-    assert dict(executed["data"]) == expected_data
-    assert "code" in executed["errors"][0]["extensions"]
-    assert executed["errors"][0]["extensions"]["code"] == PERMISSION_DENIED_ERROR
 
 
 def test_normal_user_cannot_delete_his_profile_if_service_berth_connected(
@@ -1102,16 +1073,14 @@ def test_normal_user_cannot_delete_his_profile_if_service_berth_connected(
     t = Template(
         """
             mutation {
-                deleteProfile(
-                    id: \"${id}\",
-                ) {
+                deleteMyProfile {
                     ok
                 }
             }
         """
     )
 
-    expected_data = {"deleteProfile": None}
+    expected_data = {"deleteMyProfile": None}
 
     mutation = t.substitute(id=to_global_id(type="ProfileNode", id=profile.id))
     executed = user_gql_client.execute(mutation, context=request)
@@ -1133,16 +1102,14 @@ def test_normal_user_gets_error_when_deleting_non_existent_profile(rf, user_gql_
     t = Template(
         """
             mutation {
-                deleteProfile(
-                    id: \"${id}\",
-                ) {
+                deleteMyProfile {
                     ok
                 }
             }
         """
     )
 
-    expected_data = {"deleteProfile": None}
+    expected_data = {"deleteMyProfile": None}
 
     mutation = t.substitute(id=to_global_id(type="ProfileNode", id=id))
     executed = user_gql_client.execute(mutation, context=request)

--- a/services/schema.py
+++ b/services/schema.py
@@ -1,4 +1,5 @@
 import graphene
+from django.db import transaction
 from django.db.utils import IntegrityError
 from graphene import relay
 from graphene_django.types import DjangoObjectType
@@ -48,6 +49,7 @@ class AddServiceConnection(graphene.Mutation):
     service_connection = graphene.Field(ServiceConnectionType)
 
     @login_required
+    @transaction.atomic
     def mutate(self, info, **kwargs):
         service_connection_data = kwargs.pop("service_connection")
         service_data = service_connection_data.get("service")

--- a/services/tests/test_services_graphql_api.py
+++ b/services/tests/test_services_graphql_api.py
@@ -51,7 +51,13 @@ def test_normal_user_can_add_service_mutation(rf, user_gql_client):
     t = Template(
         """
         mutation {
-            addServiceConnection(serviceConnection: { service: { type: ${service_type} } }) {
+            addServiceConnection(input: {
+                serviceConnection: {
+                    service: {
+                        type: ${service_type}
+                    }
+                }
+            }) {
                 serviceConnection {
                     service {
                         type
@@ -80,7 +86,13 @@ def test_normal_user_cannot_add_service_multiple_times_mutation(rf, user_gql_cli
     t = Template(
         """
         mutation {
-            addServiceConnection(serviceConnection: { service: { type: ${service_type} } }) {
+            addServiceConnection(input: {
+                serviceConnection: {
+                    service: {
+                        type: ${service_type}
+                    }
+                }
+            }) {
                 serviceConnection {
                     service {
                         type

--- a/youths/schema.py
+++ b/youths/schema.py
@@ -1,6 +1,7 @@
 import uuid
 
 import graphene
+from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import override
 from django.utils.translation import ugettext_lazy as _
@@ -76,6 +77,7 @@ class CreateMyYouthProfile(graphene.Mutation):
     youth_profile = graphene.Field(YouthProfileType)
 
     @login_required
+    @transaction.atomic
     def mutate(self, info, **kwargs):
         input_data = kwargs.get("youth_profile")
 
@@ -108,6 +110,7 @@ class UpdateMyYouthProfile(graphene.Mutation):
     youth_profile = graphene.Field(YouthProfileType)
 
     @login_required
+    @transaction.atomic
     def mutate(self, info, **kwargs):
         input_data = kwargs.get("youth_profile")
         resend_request_notification = input_data.pop(
@@ -146,6 +149,7 @@ class ApproveYouthProfile(graphene.Mutation):
 
     youth_profile = graphene.Field(YouthProfileType)
 
+    @transaction.atomic
     def mutate(self, info, **kwargs):
         youth_data = kwargs.get("approval_data")
         token = kwargs.get("approval_token")

--- a/youths/tests/test_youth_profiles_graphql_api.py
+++ b/youths/tests/test_youth_profiles_graphql_api.py
@@ -125,12 +125,15 @@ def test_normal_user_can_create_youth_profile_mutation(rf, user_gql_client):
         """
         mutation{
             createMyYouthProfile(
-                youthProfile: {
-                    schoolClass: "${schoolClass}"
-                    schoolName: "${schoolName}"
-                    languageAtHome: ${language}
-                    approverEmail: "${approverEmail}"
-                    birthDate: "${birthDate}"
+                input: {
+                    youthProfile: {
+                        schoolClass: "${schoolClass}"
+                        schoolName: "${schoolName}"
+                        languageAtHome: ${language}
+                        approverEmail: "${approverEmail}"
+                        birthDate: "${birthDate}"
+                    }
+
                 }
             )
             {
@@ -175,14 +178,16 @@ def test_normal_user_can_create_youth_profile_through_my_profile_mutation(
         """
             mutation {
                 createMyProfile(
-                    profile: {
-                        nickname: \"${nickname}\",
-                        youthProfile: {
-                            schoolClass: "${schoolClass}"
-                            schoolName: "${schoolName}"
-                            languageAtHome: ${language}
-                            approverEmail: "${approverEmail}"
-                            birthDate: "${birthDate}"
+                    input: {
+                        profile: {
+                            nickname: \"${nickname}\",
+                            youthProfile: {
+                                schoolClass: "${schoolClass}"
+                                schoolName: "${schoolName}"
+                                languageAtHome: ${language}
+                                approverEmail: "${approverEmail}"
+                                birthDate: "${birthDate}"
+                            }
                         }
                     }
                 ) {
@@ -239,9 +244,11 @@ def test_normal_user_can_update_youth_profile_mutation(rf, user_gql_client):
         """
         mutation{
             updateMyYouthProfile(
-                youthProfile: {
-                    schoolClass: "${schoolClass}"
-                    birthDate: "${birthDate}"
+                input: {
+                    youthProfile: {
+                        schoolClass: "${schoolClass}"
+                        birthDate: "${birthDate}"
+                    }
                 }
             )
             {
@@ -280,11 +287,13 @@ def test_normal_user_can_update_youth_profile__through_my_profile_mutation(
         """
             mutation {
                 updateMyProfile(
-                    profile: {
-                        nickname: \"${nickname}\",
-                        youthProfile: {
-                            schoolClass: "${schoolClass}"
-                            birthDate: "${birthDate}"
+                    input: {
+                        profile: {
+                            nickname: \"${nickname}\",
+                            youthProfile: {
+                                schoolClass: "${schoolClass}"
+                                birthDate: "${birthDate}"
+                            }
                         }
                     }
                 ) {
@@ -354,14 +363,16 @@ def test_anon_user_can_approve_with_token(rf, youth_profile, anon_user_gql_clien
         """
         mutation{
             approveYouthProfile(
-                approvalToken: "${token}",
-                approvalData: {
-                    photoUsageApproved: true
-                    approverFirstName: "${approver_first_name}"
-                    approverLastName: "${approver_last_name}"
-                    approverPhone: "${approver_phone}"
-                    approverEmail: "${approver_email}"
-                    birthDate: "${birthDate}"
+                input: {
+                    approvalToken: "${token}",
+                    approvalData: {
+                        photoUsageApproved: true
+                        approverFirstName: "${approver_first_name}"
+                        approverLastName: "${approver_last_name}"
+                        approverPhone: "${approver_phone}"
+                        approverEmail: "${approver_email}"
+                        birthDate: "${birthDate}"
+                    }
                 }
             )
             {

--- a/youths/tests/test_youth_profiles_graphql_api.py
+++ b/youths/tests/test_youth_profiles_graphql_api.py
@@ -124,8 +124,7 @@ def test_normal_user_can_create_youth_profile_mutation(rf, user_gql_client):
     t = Template(
         """
         mutation{
-            createYouthProfile(
-                profileId: "${profileId}"
+            createMyYouthProfile(
                 youthProfile: {
                     schoolClass: "${schoolClass}"
                     schoolName: "${schoolName}"
@@ -163,7 +162,7 @@ def test_normal_user_can_create_youth_profile_mutation(rf, user_gql_client):
         }
     }
     executed = user_gql_client.execute(query, context=request)
-    assert dict(executed["data"]["createYouthProfile"]) == expected_data
+    assert dict(executed["data"]["createMyYouthProfile"]) == expected_data
 
 
 def test_normal_user_can_create_youth_profile_through_my_profile_mutation(
@@ -175,7 +174,7 @@ def test_normal_user_can_create_youth_profile_through_my_profile_mutation(
     t = Template(
         """
             mutation {
-                createProfile(
+                createMyProfile(
                     profile: {
                         nickname: \"${nickname}\",
                         youthProfile: {
@@ -213,7 +212,7 @@ def test_normal_user_can_create_youth_profile_through_my_profile_mutation(
     query = t.substitute(**creation_data)
 
     expected_data = {
-        "createProfile": {
+        "createMyProfile": {
             "profile": {
                 "nickname": "Larry",
                 "youthProfile": {
@@ -239,7 +238,7 @@ def test_normal_user_can_update_youth_profile_mutation(rf, user_gql_client):
     t = Template(
         """
         mutation{
-            updateYouthProfile(
+            updateMyYouthProfile(
                 youthProfile: {
                     schoolClass: "${schoolClass}"
                     birthDate: "${birthDate}"
@@ -265,7 +264,7 @@ def test_normal_user_can_update_youth_profile_mutation(rf, user_gql_client):
         }
     }
     executed = user_gql_client.execute(query, context=request)
-    assert dict(executed["data"]["updateYouthProfile"]) == expected_data
+    assert dict(executed["data"]["updateMyYouthProfile"]) == expected_data
 
 
 def test_normal_user_can_update_youth_profile__through_my_profile_mutation(
@@ -280,7 +279,7 @@ def test_normal_user_can_update_youth_profile__through_my_profile_mutation(
     t = Template(
         """
             mutation {
-                updateProfile(
+                updateMyProfile(
                     profile: {
                         nickname: \"${nickname}\",
                         youthProfile: {
@@ -311,7 +310,7 @@ def test_normal_user_can_update_youth_profile__through_my_profile_mutation(
     query = t.substitute(**creation_data)
 
     expected_data = {
-        "updateProfile": {
+        "updateMyProfile": {
             "profile": {
                 "nickname": "Larry",
                 "youthProfile": {
@@ -324,101 +323,6 @@ def test_normal_user_can_update_youth_profile__through_my_profile_mutation(
     }
     executed = user_gql_client.execute(query, context=request)
     assert dict(executed["data"]) == expected_data
-
-
-def test_superuser_can_create_youth_profile_mutation(rf, superuser_gql_client, user):
-    request = rf.post("/graphql")
-    request.user = superuser_gql_client.user
-    profile = ProfileFactory(user=user)
-
-    t = Template(
-        """
-        mutation{
-            createYouthProfile(
-                profileId: "${profileId}"
-                youthProfile: {
-                    schoolClass: "${schoolClass}"
-                    schoolName: "${schoolName}"
-                    languageAtHome: ${language}
-                    approverEmail: "${approverEmail}"
-                    birthDate: "${birthDate}"
-                }
-            )
-            {
-                youthProfile {
-                    schoolClass
-                    schoolName
-                    approverEmail
-                    birthDate
-                }
-            }
-        }
-        """
-    )
-    creation_data = {
-        "profileId": profile.pk,
-        "schoolClass": "2A",
-        "schoolName": "Alakoulu",
-        "language": YouthLanguage.FINNISH.name,
-        "approverEmail": "hyvaksyja@ex.com",
-        "birthDate": "2002-02-02",
-    }
-    query = t.substitute(**creation_data)
-    expected_data = {
-        "youthProfile": {
-            "schoolClass": creation_data["schoolClass"],
-            "schoolName": creation_data["schoolName"],
-            "approverEmail": creation_data["approverEmail"],
-            "birthDate": creation_data["birthDate"],
-        }
-    }
-    executed = superuser_gql_client.execute(query, context=request)
-    assert dict(executed["data"]["createYouthProfile"]) == expected_data
-
-
-def test_superuser_can_update_youth_profile_mutation(
-    rf, youth_profile, superuser_gql_client
-):
-    request = rf.post("/graphql")
-    request.user = superuser_gql_client.user
-
-    t = Template(
-        """
-        mutation{
-            updateYouthProfile(
-                profileId: "${profileId}"
-                youthProfile: {
-                    schoolClass: "${schoolClass}"
-                    birthDate: "${birthDate}"
-                }
-            )
-            {
-                youthProfile {
-                    schoolClass
-                    schoolName
-                    approverEmail
-                    birthDate
-                }
-            }
-        }
-        """
-    )
-    creation_data = {
-        "schoolClass": "2A",
-        "profileId": youth_profile.profile.pk,
-        "birthDate": "2002-02-02",
-    }
-    query = t.substitute(**creation_data)
-    expected_data = {
-        "youthProfile": {
-            "schoolClass": creation_data["schoolClass"],
-            "schoolName": youth_profile.school_name,
-            "approverEmail": youth_profile.approver_email,
-            "birthDate": creation_data["birthDate"],
-        }
-    }
-    executed = superuser_gql_client.execute(query, context=request)
-    assert dict(executed["data"]["updateYouthProfile"]) == expected_data
 
 
 def test_anon_user_query_with_token(rf, youth_profile, anon_user_gql_client):


### PR DESCRIPTION
Refactor `Profile` and `YouthProfile` mutations to xxxMyMutation to make the separation clearer that those are only for current logged in user to mutate his profile/youth profile. No extra arguments have to be carried for these mutations as the rely heavily on logged in user to fetch all related objects. The approach in this PR is complete opposite of [this](https://github.com/City-of-Helsinki/open-city-profile/pull/91) which should be eventually closed/deleted.

Also: 
- Changed all mutations according to relay spec
- Renamed mutations to avoid name collision with relay spec mutations
- Made transactions in mutations atomic
- Cleaned up mutations of munigeo stuff