### PR TITLE
OM-345 | Configure Mailgun for test environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,3 +33,6 @@ staging:
     K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.kuva.hel.ninja/openid"
     K8S_SECRET_TOKEN_AUTH_REQUIRE_SCOPE: "True"
     K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
+    K8S_SECRET_MAIL_MAILGUN_KEY: "$SECRET_MAILGUN_API_KEY"
+    K8S_SECRET_MAIL_MAILGUN_DOMAIN: "mail.hel.ninja"
+    K8S_SECRET_MAIL_MAILGUN_API: "https://api.eu.mailgun.net/v3"


### PR DESCRIPTION
Added the domain, url and secret api key to the CI build variables. The
Mailgun variables seemed to have already been added previously to the app.