### PR TITLE
OM-345 | Change email sending from console to actual email server

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,3 +36,4 @@ staging:
     K8S_SECRET_MAIL_MAILGUN_KEY: "$SECRET_MAILGUN_API_KEY"
     K8S_SECRET_MAIL_MAILGUN_DOMAIN: "mail.hel.ninja"
     K8S_SECRET_MAIL_MAILGUN_API: "https://api.eu.mailgun.net/v3"
+    K8S_SECRET_MAILER_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"


### PR DESCRIPTION
Last time I configured the Mailgun stuff correctly, but the config was
still set to use the console output when sending emails. I added a new
config for setting the email to actually send stuff to Mailgun.