### PR TITLE
Add youth notifications generator and seeder

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,39 +1,40 @@
 include:
-  - project: 'city-of-helsinki/kuva/ci-cd-config/ci-configuration'
-    ref: v2
-    file: '/.gitlab-ci-template.yml'
+    - project: "city-of-helsinki/kuva/ci-cd-config/ci-configuration"
+      ref: v2
+      file: "/.gitlab-ci-template.yml"
 
 variables:
-  APP_MIGRATE_COMMAND: /app/.prod/on_deploy.sh
-  SERVICE_PORT: "8080"
+    APP_MIGRATE_COMMAND: /app/.prod/on_deploy.sh
+    SERVICE_PORT: "8080"
 
 build:
-  extends: .build
+    extends: .build
 
 review:
-  variables:
-    K8S_SECRET_ALLOWED_HOSTS: "*"
-    K8S_SECRET_DEBUG: 1
-    K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
+    variables:
+        K8S_SECRET_ALLOWED_HOSTS: "*"
+        K8S_SECRET_DEBUG: 1
+        K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
 
 staging:
-  only:
-    refs:
-      - develop
-  variables:
-    K8S_SECRET_ALLOWED_HOSTS: "*"
-    K8S_SECRET_DEBUG: 0
-    K8S_SECRET_OIDC_SECRET: "$GL_HEL_TEST_TUNNISTAMO_OIDC_SECRET"
-    K8S_SECRET_SECRET_KEY: "$GL_QA_DJANGO_SECRET_KEY"
-    K8S_SECRET_SENTRY_DSN: "https://c2a1cc12588942fd938d8cfdea617cb4:6fc6a7eb191a48bf9be329ca344d6dbc@sentry.hel.ninja/33"
-    K8S_SECRET_SENTRY_ENVIRONMENT: "test"
-    K8S_SECRET_SKIP_DATABASE_CHECK: 1
-    K8S_SECRET_TOKEN_AUTH_ACCEPTED_AUDIENCE: "https://api.hel.fi/auth/helsinkiprofile"
-    K8S_SECRET_TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX: "helsinkiprofile"
-    K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.kuva.hel.ninja/openid"
-    K8S_SECRET_TOKEN_AUTH_REQUIRE_SCOPE: "True"
-    K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
-    K8S_SECRET_MAIL_MAILGUN_KEY: "$SECRET_MAILGUN_API_KEY"
-    K8S_SECRET_MAIL_MAILGUN_DOMAIN: "mail.hel.ninja"
-    K8S_SECRET_MAIL_MAILGUN_API: "https://api.eu.mailgun.net/v3"
-    K8S_SECRET_MAILER_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
+    only:
+        refs:
+            - develop
+    variables:
+        K8S_SECRET_ALLOWED_HOSTS: "*"
+        K8S_SECRET_DEBUG: 0
+        K8S_SECRET_OIDC_SECRET: "$GL_HEL_TEST_TUNNISTAMO_OIDC_SECRET"
+        K8S_SECRET_SECRET_KEY: "$GL_QA_DJANGO_SECRET_KEY"
+        K8S_SECRET_SENTRY_DSN: "https://c2a1cc12588942fd938d8cfdea617cb4:6fc6a7eb191a48bf9be329ca344d6dbc@sentry.hel.ninja/33"
+        K8S_SECRET_SENTRY_ENVIRONMENT: "test"
+        K8S_SECRET_SKIP_DATABASE_CHECK: 1
+        K8S_SECRET_TOKEN_AUTH_ACCEPTED_AUDIENCE: "https://api.hel.fi/auth/helsinkiprofile"
+        K8S_SECRET_TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX: "helsinkiprofile"
+        K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.kuva.hel.ninja/openid"
+        K8S_SECRET_TOKEN_AUTH_REQUIRE_SCOPE: "True"
+        K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
+        K8S_SECRET_MAIL_MAILGUN_KEY: "$SECRET_MAILGUN_API_KEY"
+        K8S_SECRET_MAIL_MAILGUN_DOMAIN: "mail.hel.ninja"
+        K8S_SECRET_MAIL_MAILGUN_API: "https://api.eu.mailgun.net/v3"
+        K8S_SECRET_MAILER_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
+        K8S_SECRET_DEFAULT_FROM_EMAIL: "no-reply@hel.ninja"

--- a/utils/management/commands/seed_data.py
+++ b/utils/management/commands/seed_data.py
@@ -9,6 +9,7 @@ from utils.utils import (
     generate_data_fields,
     generate_group_admins,
     generate_groups_for_services,
+    generate_notifications,
     generate_profiles,
     generate_services,
     generate_youth_profiles,
@@ -69,4 +70,6 @@ class Command(BaseCommand):
             generate_profiles(profile_count, faker=faker)
             self.stdout.write("generating youth profiles...")
             generate_youth_profiles(kwargs["youthprofilepercentage"], faker=faker)
+            self.stdout.write("generating youth membership notifications...")
+            generate_notifications()
         self.stdout.write(self.style.SUCCESS("done."))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import Group
 from django.utils.timezone import get_current_timezone, make_aware
+from django_ilmoitin.models import NotificationTemplate
 from guardian.shortcuts import assign_perm
 
 from profiles.enums import AddressType, EmailType, PhoneType
@@ -11,7 +12,7 @@ from profiles.models import Address, Email, Phone, Profile
 from services.enums import ServiceType
 from services.models import AllowedDataField, Service, ServiceConnection
 from users.models import User
-from youths.enums import YouthLanguage
+from youths.enums import NotificationType, YouthLanguage
 from youths.models import YouthProfile
 
 DATA_FIELD_VALUES = [
@@ -198,3 +199,65 @@ def generate_youth_profiles(percentage=0.2, faker=None):
             else None,
             photo_usage_approved=bool(random.getrandbits(1)) if approved else False,
         )
+
+
+def generate_notifications():
+    template = NotificationTemplate(
+        type=NotificationType.YOUTH_PROFILE_CONFIRMATION_NEEDED.value
+    )
+    fi_subject = "Vahvista nuorisojäsenyys"
+    fi_html = (
+        "Hei {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} on "
+        "pyytänyt sinua vahvistamaan nuorisojäsenyytensä. Käy antamassa vahvistus Jässäri-palvelussa käyttäen tätä "
+        'linkkiä:<br /><br /><a href="https://jassari.test.kuva.hel.ninja/approve/{{ youth_profile.approval_token }}">'
+        "https://jassari.test.kuva.hel.ninja/approve/{{ youth_profile.approval_token }}</a><br /><br /><i>Tämä viesti "
+        "on lähetetty järjestelmistä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>"
+    )
+    fi_text = (
+        "Hei {{ youth_profile.approver_first_name }},\r\n\r\n{{ youth_profile.profile.first_name }} on pyytänyt sinua "
+        "vahvistamaan nuorisojäsenyytensä. Käy antamassa vahvistus Jässäri-palvelussa käyttäen tätä linkkiä:\r\n\r\n"
+        "https://jassari.test.kuva.hel.ninja/approve/{{ youth_profile.approval_token }}\r\n\r\nTämä viesti on "
+        "lähetetty järjestelmistä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä."
+    )
+    template.set_current_language("fi")
+    template.subject = fi_subject
+    template.body_html = fi_html
+    template.body_text = fi_text
+    template.set_current_language("sv")
+    template.subject = fi_subject + " SV TRANSLATION NEEDED"
+    template.body_html = fi_html + "<p>SV TRANSLATION NEEDED</p>"
+    template.body_text = fi_text + "<p>SV TRANSLATION NEEDED</p>"
+    template.set_current_language("en")
+    template.subject = fi_subject + " EN TRANSLATION NEEDED"
+    template.body_html = fi_html + "<p>EN TRANSLATION NEEDED</p>"
+    template.body_text = fi_text + "<p>EN TRANSLATION NEEDED</p>"
+    template.save()
+
+    template = NotificationTemplate(type=NotificationType.YOUTH_PROFILE_CONFIRMED.value)
+    fi_subject = "Nuorisojäsenyys vahvistettu"
+    fi_html = (
+        "Hei {{ youth_profile.profile.first_name }},\r\n<br /><br />\r\n{{ youth_profile.approver_first_name }} "
+        "on vahvistanut nuorisojäsenyytesi. Kirjaudu Jässäri-palveluun nähdäksesi omat tietosi:\r\n<br /><br />\r\n"
+        '<a href="https://jassari.test.kuva.hel.ninja">https://jassari.test.kuva.hel.ninja</a>\r\n<br /><br />\r\n<i>'
+        "Tämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei "
+        "käsitellä.</i>"
+    )
+    fi_text = (
+        "Hei {{ youth_profile.profile.first_name }},\r\n\r\n{{ youth_profile.approver_first_name }} on vahvistanut "
+        "nuorisojäsenyytesi. Kirjaudu Jässäri-palveluun nähdäksesi omat tietosi:\r\n\r\nhttps://jassari.test.kuva.h"
+        "el.ninja\r\n\r\nTämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä "
+        "vastauksia ei käsitellä."
+    )
+    template.set_current_language("fi")
+    template.subject = fi_subject
+    template.body_html = fi_html
+    template.body_text = fi_text
+    template.set_current_language("sv")
+    template.subject = fi_subject + " SV TRANSLATION NEEDED"
+    template.body_html = fi_html + "<p>SV TRANSLATION NEEDED</p>"
+    template.body_text = fi_text + "<p>SV TRANSLATION NEEDED</p>"
+    template.set_current_language("en")
+    template.subject = fi_subject + " EN TRANSLATION NEEDED"
+    template.body_html = fi_html + "<p>EN TRANSLATION NEEDED</p>"
+    template.body_text = fi_text + "<p>EN TRANSLATION NEEDED</p>"
+    template.save()


### PR DESCRIPTION
Support for generating youth notification templates programatically and added generator to be run in `seed_data`. 

Currently only finnish versions are properly translated. SV & EN are just copies of finnish with `{locale} TRANSLATION NEEDED` text added.