### PR TITLE
OM-300 | Add graphiql documentation

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -210,16 +210,40 @@ class ProfileNode(DjangoObjectType):
         connection_class = ProfilesConnection
         filterset_class = ProfileFilter
 
-    primary_email = graphene.Field(EmailNode)
-    primary_phone = graphene.Field(PhoneNode)
-    primary_address = graphene.Field(AddressNode)
-    emails = DjangoFilterConnectionField(EmailNode)
-    phones = DjangoFilterConnectionField(PhoneNode)
-    addresses = DjangoFilterConnectionField(AddressNode)
+    primary_email = graphene.Field(
+        EmailNode,
+        description="Convenience field for the email which is marked as primary."
+    )
+    primary_phone = graphene.Field(
+        PhoneNode,
+        description="Convenience field for the phone which is marked as primary."
+    )
+    primary_address = graphene.Field(
+        AddressNode,
+        description="Convenience field for the address which is marked as primary."
+    )
+    emails = DjangoFilterConnectionField(
+        EmailNode,
+        description="List of email addresses of the profile."
+    )
+    phones = DjangoFilterConnectionField(
+        PhoneNode,
+        description="List of phone numbers of the profile."
+    )
+    addresses = DjangoFilterConnectionField(
+        AddressNode,
+        description="List of addresses of the profile."
+    )
     language = Language()
     contact_method = ContactMethod()
-    service_connections = DjangoFilterConnectionField(ServiceConnectionType)
-    youth_profile = graphene.Field(YouthProfileType)
+    service_connections = DjangoFilterConnectionField(
+        ServiceConnectionType,
+        description="List of the profile's connected services."
+    )
+    youth_profile = graphene.Field(
+        YouthProfileType,
+        description="The Youth membership data of the profile."
+    )
 
     def resolve_service_connections(self, info, **kwargs):
         return ServiceConnection.objects.filter(profile=self)
@@ -353,7 +377,7 @@ class UpdateMyProfileMutation(relay.ClientIDMutation):
         return UpdateMyProfileMutation(profile=profile)
 
 
-class ClaimProfileMutation(relay.ClientIDMutation):
+class   ClaimProfileMutation(relay.ClientIDMutation):
     class Input:
         token = graphene.Argument(graphene.UUID, required=True)
         profile = ProfileInput()
@@ -409,17 +433,37 @@ class DeleteMyProfileMutation(relay.ClientIDMutation):
 
 
 class Query(graphene.ObjectType):
+    # TODO: Add the complete list of error codes
     profile = graphene.Field(
         ProfileNode,
         id=graphene.Argument(graphene.ID, required=True),
         serviceType=graphene.Argument(AllowedServiceType, required=True),
+        description="Get profile by profile ID.\n\nRequires `staff` credentials for the service given in "
+                    "`serviceType`. The profile must have an active connection to the given `serviceType`, otherwise "
+                    "it will not be returned.\n\nPossible error codes:\n\n* `TODO`",
     )
-    my_profile = graphene.Field(ProfileNode)
+    # TODO: Add the complete list of error codes
+    my_profile = graphene.Field(
+        ProfileNode,
+        description="Get the profile belonging to the currently authenticated user.\n\nRequires authentication.\n\n"
+                    "Possible error codes:\n\n* `TODO`",
+    )
+    # TODO: Add the complete list of error codes
     profiles = DjangoFilterConnectionField(
-        ProfileNode, serviceType=graphene.Argument(AllowedServiceType, required=True)
+        ProfileNode,
+        serviceType=graphene.Argument(AllowedServiceType, required=True),
+        description="Search for profiles. The results are filtered based on the given parameters. The results are "
+                    "paged using Relay.\n\nRequires `staff` credentials for the service given in "
+                    "`serviceType`. The profiles must have an active connection to the given `serviceType`, otherwise "
+                    "they will not be returned.\n\nPossible error codes:\n\n* `TODO`",
     )
+    # TODO: Add the complete list of error codes
     claimable_profile = graphene.Field(
-        ProfileNode, token=graphene.Argument(graphene.UUID, required=True)
+        ProfileNode,
+        token=graphene.Argument(graphene.UUID, required=True),
+        description="Get a profile by the given `token` so that it may be linked to the currently authenticated user. "
+                    "The profile must not already have a user account linked to it.\n\nRequires authentication.\n\n"
+                    "Possible error codes:\n\n* `TODO`",
     )
 
     @staff_required(required_permission="view")
@@ -446,7 +490,34 @@ class Query(graphene.ObjectType):
 
 
 class Mutation(graphene.ObjectType):
-    create_my_profile = CreateMyProfileMutation.Field()
-    update_my_profile = UpdateMyProfileMutation.Field()
-    delete_my_profile = DeleteMyProfileMutation.Field()
-    claim_profile = ClaimProfileMutation.Field()
+    # TODO: Add the complete list of error codes
+    create_my_profile = CreateMyProfileMutation.Field(
+        description="Creates a new profile based on the given data. The new profile is linked to the currently "
+                    "authenticated user.\n\nOne or several of the following is possible to add:\n\n* Email\n"
+                    "* Address\n* Phone\n\nIf youth data is given, a youth profile will also be created and linked "
+                    "to the profile.\n\nRequires authentication.\n\nPossible error codes:\n\n* `TODO`"
+    )
+    # TODO: Add the complete list of error codes
+    update_my_profile = UpdateMyProfileMutation.Field(
+        description="Updates the profile which is linked to the currently authenticated user based on the given data."
+                    "\n\nOne or several of the following is possible to add, modify or remove:\n\n* Email\n* Address"
+                    "\n* Phone\n\nIf youth data is given, a youth profile will also be created and linked "
+                    "to the profile **or** the existing youth profile will be updated if the profile is already"
+                    "linked to a youth profile.\n\nRequires authentication.\n\nPossible error codes:\n\n* `TODO`"
+    )
+    # TODO: Add the complete list of error codes
+    delete_my_profile = DeleteMyProfileMutation.Field(
+        description="Deletes the data of the profile which is linked to the currently authenticated user.\n\n"
+                    "Requires authentication.\n\nPossible error codes:\n\n* "
+                    "`CANNOT_DELETE_PROFILE_WHILE_SERVICE_CONNECTED_ERROR`: Returned if the profile is connected to "
+                    "Berth service.\n\n* `PROFILE_DOES_NOT_EXIST_ERROR`: Returned if there is no profile linked to the"
+                    "currently authenticated user.\n\n* `TODO`"
+    )
+    # TODO: Add the complete list of error codes
+    claim_profile = ClaimProfileMutation.Field(
+        description="Fetches a profile which has no linked user account yet by the given token and links the profile "
+                    "to the currently authenticated user's account.\n\n**NOTE:** This functionality is not implemented"
+                    " completely. If the authenticated user already has a profile, this mutation will respond with "
+                    "an error.\n\nPossible error codes:\n\n* `API_NOT_IMPLEMENTED_ERROR`: Returned if the currently"
+                    "authenticated user already has a profile.\n\n* `TODO`"
+    )

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -212,37 +212,32 @@ class ProfileNode(DjangoObjectType):
 
     primary_email = graphene.Field(
         EmailNode,
-        description="Convenience field for the email which is marked as primary."
+        description="Convenience field for the email which is marked as primary.",
     )
     primary_phone = graphene.Field(
         PhoneNode,
-        description="Convenience field for the phone which is marked as primary."
+        description="Convenience field for the phone which is marked as primary.",
     )
     primary_address = graphene.Field(
         AddressNode,
-        description="Convenience field for the address which is marked as primary."
+        description="Convenience field for the address which is marked as primary.",
     )
     emails = DjangoFilterConnectionField(
-        EmailNode,
-        description="List of email addresses of the profile."
+        EmailNode, description="List of email addresses of the profile."
     )
     phones = DjangoFilterConnectionField(
-        PhoneNode,
-        description="List of phone numbers of the profile."
+        PhoneNode, description="List of phone numbers of the profile."
     )
     addresses = DjangoFilterConnectionField(
-        AddressNode,
-        description="List of addresses of the profile."
+        AddressNode, description="List of addresses of the profile."
     )
     language = Language()
     contact_method = ContactMethod()
     service_connections = DjangoFilterConnectionField(
-        ServiceConnectionType,
-        description="List of the profile's connected services."
+        ServiceConnectionType, description="List of the profile's connected services."
     )
     youth_profile = graphene.Field(
-        YouthProfileType,
-        description="The Youth membership data of the profile."
+        YouthProfileType, description="The Youth membership data of the profile."
     )
 
     def resolve_service_connections(self, info, **kwargs):
@@ -377,7 +372,7 @@ class UpdateMyProfileMutation(relay.ClientIDMutation):
         return UpdateMyProfileMutation(profile=profile)
 
 
-class   ClaimProfileMutation(relay.ClientIDMutation):
+class ClaimProfileMutation(relay.ClientIDMutation):
     class Input:
         token = graphene.Argument(graphene.UUID, required=True)
         profile = ProfileInput()
@@ -439,31 +434,31 @@ class Query(graphene.ObjectType):
         id=graphene.Argument(graphene.ID, required=True),
         serviceType=graphene.Argument(AllowedServiceType, required=True),
         description="Get profile by profile ID.\n\nRequires `staff` credentials for the service given in "
-                    "`serviceType`. The profile must have an active connection to the given `serviceType`, otherwise "
-                    "it will not be returned.\n\nPossible error codes:\n\n* `TODO`",
+        "`serviceType`. The profile must have an active connection to the given `serviceType`, otherwise "
+        "it will not be returned.\n\nPossible error codes:\n\n* `TODO`",
     )
     # TODO: Add the complete list of error codes
     my_profile = graphene.Field(
         ProfileNode,
         description="Get the profile belonging to the currently authenticated user.\n\nRequires authentication.\n\n"
-                    "Possible error codes:\n\n* `TODO`",
+        "Possible error codes:\n\n* `TODO`",
     )
     # TODO: Add the complete list of error codes
     profiles = DjangoFilterConnectionField(
         ProfileNode,
         serviceType=graphene.Argument(AllowedServiceType, required=True),
         description="Search for profiles. The results are filtered based on the given parameters. The results are "
-                    "paged using Relay.\n\nRequires `staff` credentials for the service given in "
-                    "`serviceType`. The profiles must have an active connection to the given `serviceType`, otherwise "
-                    "they will not be returned.\n\nPossible error codes:\n\n* `TODO`",
+        "paged using Relay.\n\nRequires `staff` credentials for the service given in "
+        "`serviceType`. The profiles must have an active connection to the given `serviceType`, otherwise "
+        "they will not be returned.\n\nPossible error codes:\n\n* `TODO`",
     )
     # TODO: Add the complete list of error codes
     claimable_profile = graphene.Field(
         ProfileNode,
         token=graphene.Argument(graphene.UUID, required=True),
         description="Get a profile by the given `token` so that it may be linked to the currently authenticated user. "
-                    "The profile must not already have a user account linked to it.\n\nRequires authentication.\n\n"
-                    "Possible error codes:\n\n* `TODO`",
+        "The profile must not already have a user account linked to it.\n\nRequires authentication.\n\n"
+        "Possible error codes:\n\n* `TODO`",
     )
 
     @staff_required(required_permission="view")
@@ -493,31 +488,31 @@ class Mutation(graphene.ObjectType):
     # TODO: Add the complete list of error codes
     create_my_profile = CreateMyProfileMutation.Field(
         description="Creates a new profile based on the given data. The new profile is linked to the currently "
-                    "authenticated user.\n\nOne or several of the following is possible to add:\n\n* Email\n"
-                    "* Address\n* Phone\n\nIf youth data is given, a youth profile will also be created and linked "
-                    "to the profile.\n\nRequires authentication.\n\nPossible error codes:\n\n* `TODO`"
+        "authenticated user.\n\nOne or several of the following is possible to add:\n\n* Email\n"
+        "* Address\n* Phone\n\nIf youth data is given, a youth profile will also be created and linked "
+        "to the profile.\n\nRequires authentication.\n\nPossible error codes:\n\n* `TODO`"
     )
     # TODO: Add the complete list of error codes
     update_my_profile = UpdateMyProfileMutation.Field(
         description="Updates the profile which is linked to the currently authenticated user based on the given data."
-                    "\n\nOne or several of the following is possible to add, modify or remove:\n\n* Email\n* Address"
-                    "\n* Phone\n\nIf youth data is given, a youth profile will also be created and linked "
-                    "to the profile **or** the existing youth profile will be updated if the profile is already"
-                    "linked to a youth profile.\n\nRequires authentication.\n\nPossible error codes:\n\n* `TODO`"
+        "\n\nOne or several of the following is possible to add, modify or remove:\n\n* Email\n* Address"
+        "\n* Phone\n\nIf youth data is given, a youth profile will also be created and linked "
+        "to the profile **or** the existing youth profile will be updated if the profile is already "
+        "linked to a youth profile.\n\nRequires authentication.\n\nPossible error codes:\n\n* `TODO`"
     )
     # TODO: Add the complete list of error codes
     delete_my_profile = DeleteMyProfileMutation.Field(
         description="Deletes the data of the profile which is linked to the currently authenticated user.\n\n"
-                    "Requires authentication.\n\nPossible error codes:\n\n* "
-                    "`CANNOT_DELETE_PROFILE_WHILE_SERVICE_CONNECTED_ERROR`: Returned if the profile is connected to "
-                    "Berth service.\n\n* `PROFILE_DOES_NOT_EXIST_ERROR`: Returned if there is no profile linked to the"
-                    "currently authenticated user.\n\n* `TODO`"
+        "Requires authentication.\n\nPossible error codes:\n\n* "
+        "`CANNOT_DELETE_PROFILE_WHILE_SERVICE_CONNECTED_ERROR`: Returned if the profile is connected to "
+        "Berth service.\n\n* `PROFILE_DOES_NOT_EXIST_ERROR`: Returned if there is no profile linked to "
+        "the currently authenticated user.\n\n* `TODO`"
     )
     # TODO: Add the complete list of error codes
     claim_profile = ClaimProfileMutation.Field(
         description="Fetches a profile which has no linked user account yet by the given token and links the profile "
-                    "to the currently authenticated user's account.\n\n**NOTE:** This functionality is not implemented"
-                    " completely. If the authenticated user already has a profile, this mutation will respond with "
-                    "an error.\n\nPossible error codes:\n\n* `API_NOT_IMPLEMENTED_ERROR`: Returned if the currently"
-                    "authenticated user already has a profile.\n\n* `TODO`"
+        "to the currently authenticated user's account.\n\n**NOTE:** This functionality is not implemented"
+        " completely. If the authenticated user already has a profile, this mutation will respond with "
+        "an error.\n\nPossible error codes:\n\n* `API_NOT_IMPLEMENTED_ERROR`: Returned if the currently "
+        "authenticated user already has a profile.\n\n* `TODO`"
     )

--- a/services/schema.py
+++ b/services/schema.py
@@ -77,4 +77,8 @@ class AddServiceConnectionMutation(relay.ClientIDMutation):
 
 
 class Mutation(graphene.ObjectType):
-    add_service_connection = AddServiceConnectionMutation.Field()
+    add_service_connection = AddServiceConnectionMutation.Field(
+        description="Connect the currently authenticated user's profile to the given service.\n\nRequires "
+                    "authentication.\n\nPossible error codes:\n\n* `SERVICE_CONNECTION_ALREADY_EXISTS_ERROR`: "
+                    "Returned if the currently authenticated user's profile is already connected to the given service."
+    )

--- a/services/schema.py
+++ b/services/schema.py
@@ -79,6 +79,6 @@ class AddServiceConnectionMutation(relay.ClientIDMutation):
 class Mutation(graphene.ObjectType):
     add_service_connection = AddServiceConnectionMutation.Field(
         description="Connect the currently authenticated user's profile to the given service.\n\nRequires "
-                    "authentication.\n\nPossible error codes:\n\n* `SERVICE_CONNECTION_ALREADY_EXISTS_ERROR`: "
-                    "Returned if the currently authenticated user's profile is already connected to the given service."
+        "authentication.\n\nPossible error codes:\n\n* `SERVICE_CONNECTION_ALREADY_EXISTS_ERROR`: "
+        "Returned if the currently authenticated user's profile is already connected to the given service."
     )

--- a/youths/models.py
+++ b/youths/models.py
@@ -25,6 +25,10 @@ class YouthProfile(models.Model):
         Profile, related_name="youth_profile", on_delete=models.CASCADE
     )
     birth_date = models.DateField()
+    """hello
+    
+    hello
+    """
     school_name = models.CharField(max_length=128, blank=True)
     school_class = models.CharField(max_length=10, blank=True)
     expiration = models.DateField(default=calculate_expiration)

--- a/youths/models.py
+++ b/youths/models.py
@@ -25,10 +25,6 @@ class YouthProfile(models.Model):
         Profile, related_name="youth_profile", on_delete=models.CASCADE
     )
     birth_date = models.DateField()
-    """hello
-    
-    hello
-    """
     school_name = models.CharField(max_length=128, blank=True)
     school_class = models.CharField(max_length=10, blank=True)
     expiration = models.DateField(default=calculate_expiration)

--- a/youths/schema.py
+++ b/youths/schema.py
@@ -84,7 +84,9 @@ class YouthProfileFields(graphene.InputObjectType):
 
 # Subset of abstract fields are required for creation
 class CreateMyYouthProfileInput(YouthProfileFields):
-    approver_email = graphene.String(required=True, description="The approver's email address.")
+    approver_email = graphene.String(
+        required=True, description="The approver's email address."
+    )
     birth_date = graphene.Date(
         required=True,
         description="The youth's birth date. This is used for example to calculate if the youth is a minor or not.",
@@ -124,7 +126,7 @@ class CreateMyYouthProfileMutation(relay.ClientIDMutation):
 class UpdateYouthProfileInput(YouthProfileFields):
     resend_request_notification = graphene.Boolean(
         description="If set to `true`, a new approval token is generated and a new email notification is sent to the"
-                    "approver's email address."
+        "approver's email address."
     )
 
 
@@ -174,11 +176,11 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
     class Input:
         approval_token = graphene.String(
             required=True,
-            description="This is the token with which a youth profile may be fetched for approval purposes."
+            description="This is the token with which a youth profile may be fetched for approval purposes.",
         )
         approval_data = ApproveYouthProfileFields(
             required=True,
-            description="The youth profile data to approve. This may contain modifications done by the approver."
+            description="The youth profile data to approve. This may contain modifications done by the approver.",
         )
 
     youth_profile = graphene.Field(YouthProfileType)
@@ -218,16 +220,16 @@ class Query(graphene.ObjectType):
         YouthProfileType,
         profile_id=graphene.ID(),
         description="Get a youth profile by youth profile ID.\n\n**NOTE:** Currently this requires `superuser` "
-                    "credentials. This is going to be changed at one point so that service-specific staff "
-                    "credentials and service type are used, just like the rest of the admin-type queries.\n\n"
-                    "Possible error codes:\n\n* `TODO`",
+        "credentials. This is going to be changed at one point so that service-specific staff "
+        "credentials and service type are used, just like the rest of the admin-type queries.\n\n"
+        "Possible error codes:\n\n* `TODO`",
     )
     # TODO: Add the complete list of error codes
     youth_profile_by_approval_token = graphene.Field(
         YouthProfileType,
         token=graphene.String(),
         description="Get a youth profile by approval token. \n\nDoesn't require authentication.\n\nPossible "
-                    "error codes:\n\n* `TODO`",
+        "error codes:\n\n* `TODO`",
     )
 
     @login_required
@@ -249,23 +251,23 @@ class Mutation(graphene.ObjectType):
     # TODO: Add the complete list of error codes
     create_my_youth_profile = CreateMyYouthProfileMutation.Field(
         description="Creates a new youth profile and links it to the currently authenticated user's profile.\n\n"
-                    "When the youth profile has been created, a notification is sent to the youth profile's approver "
-                    "whose contact information is given in the input.\n\nRequires authentication.\n\nPossible error "
-                    "codes:\n\n* `TODO`"
+        "When the youth profile has been created, a notification is sent to the youth profile's approver "
+        "whose contact information is given in the input.\n\nRequires authentication.\n\nPossible error "
+        "codes:\n\n* `TODO`"
     )
     # TODO: Add the complete list of error codes
     update_my_youth_profile = UpdateMyYouthProfileMutation.Field(
         description="Updates the youth profile which belongs to the profile of the currently authenticated user.\n\n"
-                    "The `resend_request_notification` parameter may be used to send a notification to the youth "
-                    "profile's approver whose contact information is in the youth profile.\n\nRequires authentication."
-                    "\n\nPossible error codes:\n\n* `TODO`"
+        "The `resend_request_notification` parameter may be used to send a notification to the youth "
+        "profile's approver whose contact information is in the youth profile.\n\nRequires authentication."
+        "\n\nPossible error codes:\n\n* `TODO`"
     )
     # TODO: Add the complete list of error codes
     approve_youth_profile = ApproveYouthProfileMutation.Field(
         description="Fetches a youth profile using the given token, updates the data based on the given input data and"
-                    "approves the youth profile so that it is considered active. A confirmation is sent to the youth"
-                    "profile's email address after a successful approval.\n\nThe token is no longer valid after"
-                    "it's been used to approve the youth profile.\n\nRequires authentication.\n\nPossible error "
-                    "codes:\n\n* `PROFILE_HAS_NO_PRIMARY_EMAIL_ERROR`: Returned if the youth profile doesn't have a "
-                    "primary email address.\n\n* `TODO`"
+        " approves the youth profile so that it is considered active. A confirmation is sent to the youth "
+        "profile's email address after a successful approval.\n\nThe token is no longer valid after "
+        "it's been used to approve the youth profile.\n\nRequires authentication.\n\nPossible error "
+        "codes:\n\n* `PROFILE_HAS_NO_PRIMARY_EMAIL_ERROR`: Returned if the youth profile doesn't have a "
+        "primary email address.\n\n* `TODO`"
     )

--- a/youths/schema.py
+++ b/youths/schema.py
@@ -66,7 +66,7 @@ class YouthProfileFields(graphene.InputObjectType):
 
 # Subset of abstract fields are required for creation
 class CreateMyYouthProfileInput(YouthProfileFields):
-    approver_email = graphene.String(required=True)
+    approver_email = graphene.String(required=True, description="The approver's email address.")
     birth_date = graphene.Date(
         required=True,
         description="The youth's birth date. This is used for example to calculate if the youth is a minor or not.",
@@ -104,7 +104,10 @@ class CreateMyYouthProfileMutation(relay.ClientIDMutation):
 
 
 class UpdateYouthProfileInput(YouthProfileFields):
-    resend_request_notification = graphene.Boolean()
+    resend_request_notification = graphene.Boolean(
+        description="If set to `true`, a new approval token is generated and a new email notification is sent to the"
+                    "approver's email address."
+    )
 
 
 class UpdateMyYouthProfileMutation(relay.ClientIDMutation):
@@ -144,13 +147,21 @@ class UpdateMyYouthProfileMutation(relay.ClientIDMutation):
 
 class ApproveYouthProfileFields(YouthProfileFields):
     # TODO: Photo usage needs to be present also in Create/Modify, but it cannot be given, if the youth is under 15
-    photo_usage_approved = graphene.Boolean()
+    photo_usage_approved = graphene.Boolean(
+        description="`true` if the youth is allowed to be photographed."
+    )
 
 
 class ApproveYouthProfileMutation(relay.ClientIDMutation):
     class Input:
-        approval_token = graphene.String(required=True)
-        approval_data = ApproveYouthProfileFields(required=True)
+        approval_token = graphene.String(
+            required=True,
+            description="This is the token with which a youth profile may be fetched for approval purposes."
+        )
+        approval_data = ApproveYouthProfileFields(
+            required=True,
+            description="The youth profile data to approve. This may contain modifications done by the approver."
+        )
 
     youth_profile = graphene.Field(YouthProfileType)
 
@@ -184,10 +195,21 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
 
 
 class Query(graphene.ObjectType):
-    youth_profile = graphene.Field(YouthProfileType, profile_id=graphene.ID())
-
+    # TODO: Add the complete list of error codes
+    youth_profile = graphene.Field(
+        YouthProfileType,
+        profile_id=graphene.ID(),
+        description="Get a youth profile by youth profile ID.\n\n**NOTE:** Currently this requires `superuser` "
+                    "credentials. This is going to be changed at one point so that service-specific staff "
+                    "credentials and service type are used, just like the rest of the admin-type queries.\n\n"
+                    "Possible error codes:\n\n* `TODO`",
+    )
+    # TODO: Add the complete list of error codes
     youth_profile_by_approval_token = graphene.Field(
-        YouthProfileType, token=graphene.String()
+        YouthProfileType,
+        token=graphene.String(),
+        description="Get a youth profile by approval token. \n\nDoesn't require authentication.\n\nPossible "
+                    "error codes:\n\n* `TODO`",
     )
 
     @login_required
@@ -206,6 +228,26 @@ class Query(graphene.ObjectType):
 
 
 class Mutation(graphene.ObjectType):
-    create_my_youth_profile = CreateMyYouthProfileMutation.Field()
-    update_my_youth_profile = UpdateMyYouthProfileMutation.Field()
-    approve_youth_profile = ApproveYouthProfileMutation.Field()
+    # TODO: Add the complete list of error codes
+    create_my_youth_profile = CreateMyYouthProfileMutation.Field(
+        description="Creates a new youth profile and links it to the currently authenticated user's profile.\n\n"
+                    "When the youth profile has been created, a notification is sent to the youth profile's approver "
+                    "whose contact information is given in the input.\n\nRequires authentication.\n\nPossible error "
+                    "codes:\n\n* `TODO`"
+    )
+    # TODO: Add the complete list of error codes
+    update_my_youth_profile = UpdateMyYouthProfileMutation.Field(
+        description="Updates the youth profile which belongs to the profile of the currently authenticated user.\n\n"
+                    "The `resend_request_notification` parameter may be used to send a notification to the youth "
+                    "profile's approver whose contact information is in the youth profile.\n\nRequires authentication."
+                    "\n\nPossible error codes:\n\n* `TODO`"
+    )
+    # TODO: Add the complete list of error codes
+    approve_youth_profile = ApproveYouthProfileMutation.Field(
+        description="Fetches a youth profile using the given token, updates the data based on the given input data and"
+                    "approves the youth profile so that it is considered active. A confirmation is sent to the youth"
+                    "profile's email address after a successful approval.\n\nThe token is no longer valid after"
+                    "it's been used to approve the youth profile.\n\nRequires authentication.\n\nPossible error "
+                    "codes:\n\n* `PROFILE_HAS_NO_PRIMARY_EMAIL_ERROR`: Returned if the youth profile doesn't have a "
+                    "primary email address.\n\n* `TODO`"
+    )


### PR DESCRIPTION
Added initial GraphiQL descriptions for queries and mutations plus the fields which had the option for adding it. I left the possible error codes mostly as "TODO", since the actual codes must still be checked out. But there's a place now for documenting them at least.

The descriptions have some Markdown formatting in them and they look like this when viewed in a browser:

![image](https://user-images.githubusercontent.com/54528563/73820981-96c3d000-47fb-11ea-8148-fed2181e803f.png)
