### PR TITLE
Update README and gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ build:
 review:
     variables:
         K8S_SECRET_ALLOWED_HOSTS: "*"
-        K8S_SECRET_DEBUG: 1
+        K8S_SECRET_DEBUG: 0
         K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
 
 staging:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Open city profile
 
+**This is a version of the app which is used for the MyDataShare pilot**
+
 ## Summary
 
 Open city profile is used to store common information (name, contact 


### PR DESCRIPTION
I just updated the readme and gitlab-ci.yml in order to get a CI build going. The MyDataShare pilot needs a new instance of the app so that they can test their access gateway and using the review instance was suggested as the easiest way.