### PR TITLE
OM-239 | Pass correct language to send_notification

### DIFF
--- a/youths/models.py
+++ b/youths/models.py
@@ -73,6 +73,7 @@ class YouthProfile(models.Model):
             email=self.approver_email,
             notification_type=NotificationType.YOUTH_PROFILE_CONFIRMATION_NEEDED.value,
             context={"youth_profile": self},
+            language=self.language_at_home.value,
         )
         self.approval_notification_timestamp = timezone.now()
 

--- a/youths/schema.py
+++ b/youths/schema.py
@@ -270,6 +270,7 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
             email=email.email,
             notification_type=NotificationType.YOUTH_PROFILE_CONFIRMED.value,
             context={"youth_profile": youth_profile},
+            language=youth_profile.profile.language if youth_profile.profile else "fi",
         )
         return ApproveYouthProfileMutation(youth_profile=youth_profile)
 


### PR DESCRIPTION
- Use `youth_profile.language_at_home` in approval notification
- Use `profile.language` in confirmed notification