### PR TITLE
OM-596 | Fix approve adult youths created via updateprofile

### DIFF
--- a/youths/tests/test_youth_profiles_graphql_api.py
+++ b/youths/tests/test_youth_profiles_graphql_api.py
@@ -793,6 +793,7 @@ def test_normal_user_can_add_youth_profile_through_update_my_profile_mutation(
                     youthProfile {
                         schoolClass
                         birthDate
+                        membershipStatus
                     }
                 }
             }
@@ -815,6 +816,7 @@ def test_normal_user_can_add_youth_profile_through_update_my_profile_mutation(
                 "youthProfile": {
                     "schoolClass": creation_data["schoolClass"],
                     "birthDate": creation_data["birthDate"],
+                    "membershipStatus": "ACTIVE",
                 },
             }
         }


### PR DESCRIPTION
Over 18 years old youth profiles were left in `PENDING` state if they were created via `updateMyProfile` mutation. Now this is fixed and backed up by a test.