### PR TITLE
Allow JWT tokens to be valid for 1 hour

### DIFF
--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -189,6 +189,8 @@ OIDC_API_TOKEN_AUTH = {
     "REQUIRE_API_SCOPE_FOR_AUTHENTICATION": env.bool("TOKEN_AUTH_REQUIRE_SCOPE"),
 }
 
+OIDC_AUTH = {"OIDC_LEEWAY": 60 * 60}
+
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
     "open_city_profile.oidc.GraphQLApiTokenAuthentication",


### PR DESCRIPTION
This will allow us using JWT's `exp` value for up to 60 mins 
in the future. Default `OIDC_LEEWAY` considers them invalid
after 15 mins.