### PR TITLE
OM-670 | Add filtering profiles by subscriptions

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -166,6 +166,7 @@ class ProfileFilter(FilterSet):
             "addresses__address_type",
             "addresses__primary",
             "language",
+            "enabled_subscriptions",
         )
 
     first_name = CharFilter(lookup_expr="icontains")
@@ -184,6 +185,7 @@ class ProfileFilter(FilterSet):
     addresses__address_type = ChoiceFilter(choices=AddressType.choices())
     addresses__primary = BooleanFilter()
     language = CharFilter()
+    enabled_subscriptions = CharFilter(method="get_enabled_subscriptions")
     order_by = OrderingFilter(
         fields=(
             ("first_name", "firstName"),
@@ -192,6 +194,14 @@ class ProfileFilter(FilterSet):
             ("language", "language"),
         )
     )
+
+    def get_enabled_subscriptions(self, queryset, name, value):
+        """
+        Custom filter to join the enabled of subscription with subscription type correctly
+        """
+        return queryset.filter(
+            subscriptions__enabled=True, subscriptions__subscription_type__code=value
+        )
 
 
 class ContactNode(DjangoObjectType):


### PR DESCRIPTION
Just chaining the "built-in" filters won't do the trick because they aren't executed in the same filter. One way to solve this would have been to call `_next_is_sticky` for the queryset but it would have required maybe too much information about underlying stuff and order of filters. 

Since at least for now the case is always to find subscription types by code and return only profiles that have subscribed to those (`enabled=True`) I found it best option to just have a custom filter for this.