### PR TITLE
Allow fetching profiles from federation gateway

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -45,7 +45,12 @@ from youths.schema import (
 
 from .enums import AddressType, EmailType, PhoneType
 from .models import Address, ClaimToken, Contact, Email, Phone, Profile, SensitiveData
-from .utils import create_nested, delete_nested, update_nested
+from .utils import (
+    create_nested,
+    delete_nested,
+    update_nested,
+    user_has_staff_perms_to_view_profile,
+)
 
 AllowedEmailType = graphene.Enum.from_enum(
     EmailType, description=lambda e: e.label if e else ""
@@ -329,6 +334,22 @@ class ProfileNode(DjangoObjectType):
         else:
             # TODO: We should return PermissionDenied as a partial error here.
             return None
+
+    @login_required
+    def __resolve_reference(self, info, **kwargs):
+        profile = graphene.Node.get_node_from_global_id(
+            info, self.id, only_type=ProfileNode
+        )
+        if not profile:
+            return None
+
+        user = info.context.user
+        if user == profile.user or user_has_staff_perms_to_view_profile(user, profile):
+            return profile
+        else:
+            raise PermissionDenied(
+                _("You do not have permission to perform this action.")
+            )
 
 
 class EmailInput(graphene.InputObjectType):

--- a/profiles/tests/test_profile_utils.py
+++ b/profiles/tests/test_profile_utils.py
@@ -1,0 +1,28 @@
+import pytest
+from guardian.shortcuts import assign_perm
+
+from open_city_profile.tests.factories import GroupFactory
+from services.enums import ServiceType
+from services.tests.factories import ServiceConnectionFactory, ServiceFactory
+
+from ..utils import user_has_staff_perms_to_view_profile
+from .factories import ProfileFactory, UserFactory
+
+
+@pytest.mark.parametrize("user_should_have_perms", [True, False])
+def test_user_has_admin_perms_to_view_profile_util(user_should_have_perms):
+    service_1 = ServiceFactory(service_type=ServiceType.BERTH)
+    service_2 = ServiceFactory(service_type=ServiceType.YOUTH_MEMBERSHIP)
+    group = GroupFactory()
+    user = UserFactory()
+    user.groups.add(group)
+    assign_perm("can_view_profiles", group, service_1)
+
+    profile = ProfileFactory()
+
+    if user_should_have_perms:
+        ServiceConnectionFactory(profile=profile, service=service_1)
+        assert user_has_staff_perms_to_view_profile(user, profile)
+    else:
+        ServiceConnectionFactory(profile=profile, service=service_2)
+        assert not user_has_staff_perms_to_view_profile(user, profile)

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -1,6 +1,12 @@
 import threading
+from typing import TYPE_CHECKING
 
 from graphql_relay.node.node import from_global_id
+
+if TYPE_CHECKING:
+    import profiles.models
+    import users.models
+
 
 _thread_locals = threading.local()
 
@@ -47,3 +53,20 @@ def get_current_user():
 
 def get_current_service():
     return getattr(_thread_locals, "service", None)
+
+
+def user_has_staff_perms_to_view_profile(
+    user: "users.models.User", profile: "profiles.models.Profile"
+) -> bool:
+    """
+    Checks is passed user has "can_view_profiles" permissions
+    for any service connected to the passed profile.
+    """
+
+    service_conns = profile.service_connections.filter(enabled=True)
+    return any(
+        [
+            user.has_perm("can_view_profiles", service_conn.service)
+            for service_conn in service_conns
+        ]
+    )


### PR DESCRIPTION
Apollo-federation gateway requires having __resolve_reference
method for all the federated objects across federated backends.

We cannot easily make federation gateway pass serviceType as
query parameter, so we will check if the request user has perms
to view profiles for any of the services connected to the profile
being fetched.