### PR TITLE
OM-595 | Add subscriptions into the downloadable JSON data

### DIFF
--- a/profiles/models.py
+++ b/profiles/models.py
@@ -107,6 +107,7 @@ class Profile(UUIDModel, SerializableMixin):
         {"name": "phones"},
         {"name": "addresses"},
         {"name": "service_connections"},
+        {"name": "subscriptions"},
     )
     audit_log = True
 

--- a/profiles/tests/test_profiles_graphql_api.py
+++ b/profiles/tests/test_profiles_graphql_api.py
@@ -2453,6 +2453,7 @@ def test_user_can_download_profile(rf, user_gql_client):
                 {"key": "PHONES", "children": []},
                 {"key": "ADDRESSES", "children": []},
                 {"key": "SERVICE_CONNECTIONS", "children": []},
+                {"key": "SUBSCRIPTIONS", "children": []},
             ],
         }
     )

--- a/subscriptions/models.py
+++ b/subscriptions/models.py
@@ -3,6 +3,8 @@ from django.db import models
 from django.db.models import Max
 from parler.models import TranslatableModel, TranslatedFields
 
+from utils.models import SerializableMixin
+
 
 def get_next_subscription_type_category_order():
     order_max = SubscriptionTypeCategory.objects.aggregate(Max("order"))["order__max"]
@@ -49,7 +51,7 @@ class SubscriptionType(TranslatableModel, SortableMixin):
         return self.code
 
 
-class Subscription(models.Model):
+class Subscription(SerializableMixin):
     profile = models.ForeignKey(
         "profiles.Profile", on_delete=models.CASCADE, related_name="subscriptions"
     )
@@ -61,3 +63,9 @@ class Subscription(models.Model):
 
     def __str__(self):
         return f"{self.subscription_type.code}: {self.enabled}"
+
+    serialize_fields = (
+        {"name": "subscription_type", "accessor": lambda x: getattr(x, "code")},
+        {"name": "created_at", "accessor": lambda x: x.strftime("%Y-%m-%d")},
+        {"name": "enabled"},
+    )


### PR DESCRIPTION
I added the necessary configs so that the Subscription model can also be
serialized into JSON format as part of the Profile which is going to be
downloaded.