### PR TITLE
OM-715 | Change the youth membership end date

### DIFF
--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -267,6 +267,13 @@ if "SECRET_KEY" not in locals():
 # For example, PK 123, length 6 --> 000123.
 YOUTH_MEMBERSHIP_NUMBER_LENGTH = 6
 
+# Date (day, month) for when the memberships are set to expire
+YOUTH_MEMBERSHIP_SEASON_END_DATE = 31, 8
+
+# Month from which on the membership will last until the next year, instead of ending in the current year
+YOUTH_MEMBERSHIP_FULL_SEASON_START_MONTH = 5
+
+
 AUDIT_LOGGING_ENABLED = env.bool("AUDIT_LOGGING_ENABLED")
 LOGGING = {
     "version": 1,

--- a/youths/models.py
+++ b/youths/models.py
@@ -15,13 +15,17 @@ from .enums import YouthLanguage as LanguageAtHome
 
 
 def calculate_expiration(from_date=date.today()):
-    # Membership always expires at the end of the season (31.7.).
-    # Signups before May expire in the summer of the same year, others next year.
-    return date(
-        year=from_date.year + 1 if from_date.month > 4 else from_date.year,
-        month=7,
-        day=31,
+    """Calculates the expiration date for a youth membership based on the given date.
+
+    Membership always expires at the end of the season. Signups made before the long season start month
+    expire in the summer of the same year, others next year.
+    """
+    full_season_start = settings.YOUTH_MEMBERSHIP_FULL_SEASON_START_MONTH
+    expiration_day, expiration_month = settings.YOUTH_MEMBERSHIP_SEASON_END_DATE
+    expiration_year = (
+        from_date.year + 1 if from_date.month >= full_season_start else from_date.year
     )
+    return date(year=expiration_year, month=expiration_month, day=expiration_day)
 
 
 @reversion.register()

--- a/youths/tests/conftest.py
+++ b/youths/tests/conftest.py
@@ -8,3 +8,9 @@ from youths.tests.factories import YouthProfileFactory
 @pytest.fixture
 def youth_profile(profile):
     return YouthProfileFactory(profile=profile)
+
+
+@pytest.fixture(autouse=True)
+def setup_youth_membership_dates(settings):
+    settings.YOUTH_MEMBERSHIP_SEASON_END_DATE = 31, 8
+    settings.YOUTH_MEMBERSHIP_FULL_SEASON_START_MONTH = 5

--- a/youths/tests/test_youth_profiles_graphql_api.py
+++ b/youths/tests/test_youth_profiles_graphql_api.py
@@ -995,7 +995,7 @@ def test_youth_profile_should_show_correct_membership_status(rf, user_gql_client
     """
 
     with freeze_time("2020-05-01"):
-        youth_profile.expiration = date(2020, 7, 31)
+        youth_profile.expiration = date(2020, 8, 31)
         youth_profile.approved_time = date(2019, 8, 1)
         youth_profile.save()
         expected_data = {
@@ -1004,8 +1004,8 @@ def test_youth_profile_should_show_correct_membership_status(rf, user_gql_client
         executed = user_gql_client.execute(query, context=request)
         assert dict(executed["data"]) == expected_data
 
-    with freeze_time("2020-08-01"):
-        youth_profile.expiration = date(2021, 7, 31)
+    with freeze_time("2020-09-01"):
+        youth_profile.expiration = date(2021, 8, 31)
         youth_profile.approved_time = date(2020, 4, 30)
         youth_profile.save()
         expected_data = {
@@ -1015,7 +1015,7 @@ def test_youth_profile_should_show_correct_membership_status(rf, user_gql_client
         assert dict(executed["data"]) == expected_data
 
         youth_profile.approved_time = timezone.datetime(2020, 1, 1)
-        youth_profile.expiration = date(2021, 7, 31)
+        youth_profile.expiration = date(2021, 8, 31)
         youth_profile.save()
         expected_data = {
             "youthProfile": {"membershipStatus": "RENEWING", "renewable": False}
@@ -1023,7 +1023,7 @@ def test_youth_profile_should_show_correct_membership_status(rf, user_gql_client
         with freeze_time("2020-05-01"):
             executed = user_gql_client.execute(query, context=request)
             assert dict(executed["data"]) == expected_data
-        with freeze_time("2020-07-31"):
+        with freeze_time("2020-08-31"):
             executed = user_gql_client.execute(query, context=request)
             assert dict(executed["data"]) == expected_data
 
@@ -1063,7 +1063,7 @@ def test_youth_profile_expiration_should_renew_and_be_approvable(
         assert dict(executed["data"]) == expected_data
 
     # Later in the year 2021, let's check our membership status
-    with freeze_time("2021-08-01"):
+    with freeze_time("2021-09-01"):
         query = """
             {
                 youthProfile {


### PR DESCRIPTION
Change the youth membership period to end 31.8. of the current year. Besides changing the end date, important dates related to the youth membership are made configurable.