### PR TITLE
Add missing configuration into subscriptions' initial migration

### DIFF
--- a/subscriptions/migrations/0001_initial.py
+++ b/subscriptions/migrations/0001_initial.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False},
+            options={"abstract": False, "ordering": ["order"]},
             bases=(parler.models.TranslatableModelMixin, models.Model),
         ),
         migrations.CreateModel(
@@ -70,7 +70,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            options={"abstract": False},
+            options={"abstract": False, "ordering": ["order"]},
             bases=(parler.models.TranslatableModelMixin, models.Model),
         ),
         migrations.CreateModel(


### PR DESCRIPTION
Add missing configuration into the initial migration. Adding a separate migration doesn't seem to cause any SQL to be run, so the change is simply made into the initial migration.