### PR TITLE
Add flake8 plugin pep8-naming into pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3    
+    python: python3
 repos:
   - repo: https://github.com/psf/black
     rev: 19.10b0
@@ -10,6 +10,7 @@ repos:
     hooks:
       - id: flake8
         exclude: "migrations"
+        additional_dependencies: ["pep8-naming"]
   - repo: https://github.com/timothycrosley/isort
     rev: 4.3.21
     hooks:


### PR DESCRIPTION
pre-commit config was missing `pep8-naming` plugin for `flake8` which made it miss some errors noticed on Travis.