### PR TITLE
OM-756 | Disable GraphiQL interface on production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,7 @@ staging:
         K8S_SECRET_MAILER_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
         K8S_SECRET_DEFAULT_FROM_EMAIL: "no-reply@hel.ninja"
         K8S_SECRET_FIELD_ENCRYPTION_KEYS: "$GL_QA_FIELD_ENCRYPTION_KEYS"
+        K8S_SECRET_ENABLE_GRAPHIQL: 1
 
 production:
     variables:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Prerequisites:
    * Set entrypoint/startup variables according to taste.
      * `CREATE_SUPERUSER`, creates a superuser with credentials `admin`:`admin` (admin@example.com)
      * `APPLY_MIGRATIONS`, applies migrations on startup
+     * `ENABLE_GRAPHIQL`, enables GraphiQL interface for `/graphql/`
      * `BOOTSTRAP_DIVISIONS`, bootstrap data import for divisions
 
 2. Run `docker-compose up`

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -98,6 +98,8 @@ TIME_ZONE = "Europe/Helsinki"
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True
+# Set to True to enable GraphiQL interface, this will overriden to True if DEBUG=True
+ENABLE_GRAPHIQL = env("ENABLE_GRAPHIQL")
 
 INSTALLED_APPS = [
     "helusers",

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -44,6 +44,7 @@ env = environ.Env(
     FIELD_ENCRYPTION_KEYS=(list, []),
     VERSION=(str, None),
     AUDIT_LOGGING_ENABLED=(bool, False),
+    ENABLE_GRAPHIQL=(bool, False),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)

--- a/open_city_profile/urls.py
+++ b/open_city_profile/urls.py
@@ -10,7 +10,12 @@ from open_city_profile.views import GraphQLView
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("accounts/", include("allauth.urls")),
-    path("graphql/", csrf_exempt(GraphQLView.as_view(graphiql=True))),
+    path(
+        "graphql/",
+        csrf_exempt(
+            GraphQLView.as_view(graphiql=settings.ENABLE_GRAPHIQL or settings.DEBUG)
+        ),
+    ),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
This PR adds configuration that allows enabling GraphiQL interface. By default it's disabled. GraphiQL is enabled when `DEBUG` or `ENABLE_GRAPHIQL` are set to `True`.

**TODO**
- [x] Add `ENABLE_GRAPHIQL` to readme