### PR TITLE
Make youth profile GraphQL tests more robust by using timedelta

### DIFF
--- a/youths/tests/test_youth_profiles_graphql_api.py
+++ b/youths/tests/test_youth_profiles_graphql_api.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from string import Template
 
 from django.utils import timezone
@@ -220,13 +220,12 @@ def test_normal_user_over_18_years_old_can_create_approved_youth_profile_mutatio
         }
         """
     )
+    birth_date = today.replace(year=today.year - 18) - timedelta(days=1)
     creation_data = {
         "profileId": profile.pk,
         "schoolClass": "2A",
         "schoolName": "Alakoulu",
-        "birthDate": today.replace(year=today.year - 18, day=today.day - 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birthDate": birth_date.strftime("%Y-%m-%d"),
     }
     query = t.substitute(**creation_data)
     expected_data = {
@@ -268,11 +267,10 @@ def test_user_cannot_create_youth_profile_without_approver_email_field_if_under_
         }
         """
     )
+    birth_date = today.replace(year=today.year - 18) + timedelta(days=1)
     creation_data = {
         "profileId": profile.pk,
-        "birthDate": today.replace(year=today.year - 18, day=today.day + 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birthDate": birth_date.strftime("%Y-%m-%d"),
     }
     query = t.substitute(**creation_data)
     executed = user_gql_client.execute(query, context=request)
@@ -315,15 +313,14 @@ def test_user_cannot_create_youth_profile_if_under_13_years_old(rf, user_gql_cli
         }
         """
     )
+    birth_date = today.replace(year=today.year - 13) + timedelta(days=1)
     creation_data = {
         "profileId": profile.pk,
         "schoolClass": "2A",
         "schoolName": "Alakoulu",
         "approverEmail": "hyvaksyja@ex.com",
         "language": YouthLanguage.FINNISH.name,
-        "birthDate": today.replace(year=today.year - 13, day=today.day + 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birthDate": birth_date.strftime("%Y-%m-%d"),
     }
     query = t.substitute(**creation_data)
     executed = user_gql_client.execute(query, context=request)
@@ -365,13 +362,12 @@ def test_user_can_create_youth_profile_with_photo_usage_field_if_over_15_years_o
         }
         """
     )
+    birth_date = today.replace(year=today.year - 15) - timedelta(days=1)
     creation_data = {
         "profileId": profile.pk,
         "approverEmail": "hyvaksyja@ex.com",
         "photoUsageApproved": "true",
-        "birthDate": today.replace(year=today.year - 15, day=today.day - 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birthDate": birth_date.strftime("%Y-%m-%d"),
     }
     query = t.substitute(**creation_data)
     expected_data = {
@@ -416,13 +412,12 @@ def test_user_cannot_create_youth_profile_with_photo_usage_field_if_under_15_yea
         }
         """
     )
+    birth_date = today.replace(year=today.year - 15) + timedelta(days=1)
     creation_data = {
         "profileId": profile.pk,
         "approverEmail": "hyvaksyja@ex.com",
         "photoUsageApproved": "true",
-        "birthDate": today.replace(year=today.year - 15, day=today.day + 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birthDate": birth_date.strftime("%Y-%m-%d"),
     }
     query = t.substitute(**creation_data)
     executed = user_gql_client.execute(query, context=request)
@@ -569,11 +564,10 @@ def test_user_can_update_youth_profile_with_photo_usage_field_if_over_15_years_o
         }
         """
     )
+    birth_date = today.replace(year=today.year - 15) - timedelta(days=1)
     creation_data = {
         "photoUsageApproved": "true",
-        "birthDate": today.replace(year=today.year - 15, day=today.day - 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birthDate": birth_date.strftime("%Y-%m-%d"),
     }
     query = t.substitute(**creation_data)
     expected_data = {
@@ -616,11 +610,10 @@ def test_user_cannot_update_youth_profile_with_photo_usage_field_if_under_15_yea
         }
         """
     )
+    birth_date = today.replace(year=today.year - 15) + timedelta(days=1)
     creation_data = {
         "photoUsageApproved": "true",
-        "birthDate": today.replace(year=today.year - 15, day=today.day + 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birthDate": birth_date.strftime("%Y-%m-%d"),
     }
     query = t.substitute(**creation_data)
     executed = user_gql_client.execute(query, context=request)
@@ -639,7 +632,7 @@ def test_user_can_update_youth_profile_with_photo_usage_field_if_over_15_years_o
 
     profile = ProfileFactory(user=user_gql_client.user)
     today = date.today()
-    birth_date = today.replace(year=today.year - 15, day=today.day - 1)
+    birth_date = today.replace(year=today.year - 15) - timedelta(days=1)
     YouthProfileFactory(profile=profile, birth_date=birth_date)
 
     t = Template(
@@ -675,7 +668,7 @@ def test_user_cannot_update_youth_profile_with_photo_usage_field_if_under_15_yea
 
     profile = ProfileFactory(user=user_gql_client.user)
     today = date.today()
-    birth_date = today.replace(year=today.year - 15, day=today.day + 1)
+    birth_date = today.replace(year=today.year - 15) + timedelta(days=1)
     YouthProfileFactory(profile=profile, birth_date=birth_date)
 
     t = Template(
@@ -1229,12 +1222,10 @@ def test_staff_user_can_create_youth_profile(rf, user_gql_client, phone_data):
     profile = ProfileFactory()
     request = rf.post("/graphql")
     request.user = user
-
     today = date.today()
+    birth_date = today.replace(year=today.year - 13) - timedelta(days=1)
     youth_profile_data = {
-        "birth_date": today.replace(year=today.year - 13, day=today.day - 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birth_date": birth_date.strftime("%Y-%m-%d"),
         "school_name": "Koulu",
         "school_class": "2B",
         "language_at_home": YouthLanguage.ENGLISH.name,
@@ -1320,10 +1311,9 @@ def test_staff_user_can_create_youth_profile_for_under_13_years_old(
     request.user = user
 
     today = date.today()
+    birth_date = today.replace(year=today.year - 13) + timedelta(days=1)
     youth_profile_data = {
-        "birth_date": today.replace(year=today.year - 13, day=today.day + 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birth_date": birth_date.strftime("%Y-%m-%d"),
         "approver_email": "jane.doe@example.com",
     }
 
@@ -1376,9 +1366,8 @@ def test_staff_user_can_create_youth_profile_via_create_profile(rf, user_gql_cli
     request.user = user
 
     today = date.today()
-    birth_date = today.replace(year=today.year - 13, day=today.day - 1).strftime(
-        "%Y-%m-%d"
-    )
+    birth_date = today.replace(year=today.year - 13) - timedelta(days=1)
+    birth_date_string = birth_date.strftime("%Y-%m-%d")
 
     t = Template(
         """
@@ -1421,7 +1410,7 @@ def test_staff_user_can_create_youth_profile_via_create_profile(rf, user_gql_cli
         service_type=ServiceType.YOUTH_MEMBERSHIP.name,
         first_name="John",
         last_name="Doe",
-        birth_date=birth_date,
+        birth_date=birth_date_string,
         approver_email="jane.doe@example.com",
     )
     expected_data = {
@@ -1430,7 +1419,7 @@ def test_staff_user_can_create_youth_profile_via_create_profile(rf, user_gql_cli
                 "firstName": "John",
                 "lastName": "Doe",
                 "youthProfile": {
-                    "birthDate": birth_date,
+                    "birthDate": birth_date_string,
                     "approverEmail": "jane.doe@example.com",
                 },
                 "serviceConnections": {
@@ -1466,10 +1455,9 @@ def test_staff_user_cannot_create_youth_profile_with_invalid_service_type(
     request.user = user
 
     today = date.today()
+    birth_date = today.replace(year=today.year - 13) - timedelta(days=1)
     youth_profile_data = {
-        "birth_date": today.replace(year=today.year - 13, day=today.day - 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birth_date": birth_date.strftime("%Y-%m-%d"),
         "approver_email": "jane.doe@example.com",
     }
 
@@ -1515,10 +1503,9 @@ def test_normal_user_cannot_use_create_youth_profile_mutation(rf, user_gql_clien
     request.user = user
 
     today = date.today()
+    birth_date = today.replace(year=today.year - 13) - timedelta(days=1)
     youth_profile_data = {
-        "birth_date": today.replace(year=today.year - 13, day=today.day - 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "birth_date": birth_date.strftime("%Y-%m-%d"),
         "approver_email": "jane.doe@example.com",
     }
 
@@ -1616,11 +1603,10 @@ def test_staff_user_can_cancel_youth_membership_on_selected_date(rf, user_gql_cl
     request.user = user
 
     today = date.today()
+    expiration_date = today + timedelta(days=1)
     youth_profile_data = {
         "profile_id": to_global_id(type="ProfileNode", id=profile.pk),
-        "expiration": today.replace(year=today.year, day=today.day + 1).strftime(
-            "%Y-%m-%d"
-        ),
+        "expiration": expiration_date.strftime("%Y-%m-%d"),
     }
 
     t = Template(
@@ -1703,7 +1689,8 @@ def test_normal_user_can_cancel_youth_membership(rf, user_gql_client):
     YouthProfileFactory(profile=profile, approved_time=datetime.now())
 
     today = date.today()
-    expiration = today.replace(year=today.year, day=today.day + 1).strftime("%Y-%m-%d")
+    expiration = today + timedelta(days=1)
+    expiration_string = expiration.strftime("%Y-%m-%d")
 
     t = Template(
         """
@@ -1722,10 +1709,10 @@ def test_normal_user_can_cancel_youth_membership(rf, user_gql_client):
         }
         """
     )
-    query = t.substitute(expiration=expiration)
+    query = t.substitute(expiration=expiration_string)
 
     expected_data = {
-        "youthProfile": {"expiration": expiration, "membershipStatus": "EXPIRED"}
+        "youthProfile": {"expiration": expiration_string, "membershipStatus": "EXPIRED"}
     }
     executed = user_gql_client.execute(query, context=request)
     assert dict(executed["data"]["cancelMyYouthProfile"]) == expected_data


### PR DESCRIPTION
Tests were consistently failing when run on first or last day of the month.