### PR TITLE
OM-763 | Check staff permission when managing sensitive data

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -630,7 +630,7 @@ class UpdateProfileMutation(relay.ClientIDMutation):
         if sensitive_data:
             update_sensitivedata(profile, sensitive_data)
 
-        return UpdateMyProfileMutation(profile=profile)
+        return UpdateProfileMutation(profile=profile)
 
 
 class ClaimProfileMutation(relay.ClientIDMutation):

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -608,6 +608,7 @@ class UpdateProfileMutation(relay.ClientIDMutation):
     @staff_required(required_permission="manage")
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
+        service = Service.objects.get(service_type=input["service_type"])
         # serviceType passed on to the sub resolvers
         info.context.service_type = input["service_type"]
         profile_data = input.get("profile")
@@ -628,7 +629,12 @@ class UpdateProfileMutation(relay.ClientIDMutation):
             )
 
         if sensitive_data:
-            update_sensitivedata(profile, sensitive_data)
+            if info.context.user.has_perm("can_manage_sensitivedata", service):
+                update_sensitivedata(profile, sensitive_data)
+            else:
+                raise PermissionDenied(
+                    _("You do not have permission to perform this action.")
+                )
 
         return UpdateProfileMutation(profile=profile)
 


### PR DESCRIPTION
Staff needs `can_manage_sensitivedata` permission to modify sensitive data.