### PR TITLE
OM-788 | Make possible to set script name via env

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,3 +60,4 @@ production:
         K8S_SECRET_MAILER_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
         K8S_SECRET_DEFAULT_FROM_EMAIL: "no-reply@hel.ninja"
         K8S_SECRET_FIELD_ENCRYPTION_KEYS: "$GL_STABLE_FIELD_ENCRYPTION_KEYS"
+        FORCE_SCRIPT_NAME: "/profiili"

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -46,6 +46,7 @@ env = environ.Env(
     AUDIT_LOGGING_ENABLED=(bool, False),
     GDPR_API_ENABLED=(bool, False),
     ENABLE_GRAPHIQL=(bool, False),
+    FORCE_SCRIPT_NAME=(str, ""),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -92,6 +93,9 @@ FIELD_ENCRYPTION_KEYS = env.list("FIELD_ENCRYPTION_KEYS")
 
 ROOT_URLCONF = "open_city_profile.urls"
 WSGI_APPLICATION = "open_city_profile.wsgi.application"
+
+if env.str("FORCE_SCRIPT_NAME"):
+    FORCE_SCRIPT_NAME = env.str("FORCE_SCRIPT_NAME")
 
 LANGUAGES = (("fi", "Finnish"), ("en", "English"), ("sv", "Swedish"))
 


### PR DESCRIPTION
Make it possible to set `FORCE_SCRIPT_NAME` via envinronment variable. The use case for this is to be able to set `FORCE_SCRIPT_NAME` to `/profiili` in production in order to make it work with `https://api.hel.fi/profiili`