### PR TITLE
Fix FORCE_SCRIPT config so that it's prefixed correctly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,4 +60,4 @@ production:
         K8S_SECRET_MAILER_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
         K8S_SECRET_DEFAULT_FROM_EMAIL: "no-reply@hel.ninja"
         K8S_SECRET_FIELD_ENCRYPTION_KEYS: "$GL_STABLE_FIELD_ENCRYPTION_KEYS"
-        FORCE_SCRIPT_NAME: "/profiili"
+        K8S_SECRET_FORCE_SCRIPT_NAME: "/profiili"


### PR DESCRIPTION
FORCE_SCRIPT build variable was missing the K8S_SECRET_ prefix. I added it.