### PR TITLE
Fix URL and cookie configurations for prod environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ staging:
         K8S_SECRET_TOKEN_AUTH_ACCEPTED_AUDIENCE: "https://api.hel.fi/auth/helsinkiprofile"
         K8S_SECRET_TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX: "helsinkiprofile"
         K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://tunnistamo.test.kuva.hel.ninja/openid"
-        K8S_SECRET_TOKEN_AUTH_REQUIRE_SCOPE: "True"
+        K8S_SECRET_TOKEN_AUTH_REQUIRE_SCOPE: 1
         K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
         K8S_SECRET_MAIL_MAILGUN_KEY: "$GL_MAILGUN_API_KEY"
         K8S_SECRET_MAIL_MAILGUN_DOMAIN: "mail.hel.ninja"
@@ -40,6 +40,7 @@ staging:
         K8S_SECRET_DEFAULT_FROM_EMAIL: "no-reply@hel.ninja"
         K8S_SECRET_FIELD_ENCRYPTION_KEYS: "$GL_QA_FIELD_ENCRYPTION_KEYS"
         K8S_SECRET_ENABLE_GRAPHIQL: 1
+        K8S_SECRET_SESSION_COOKIE_SECURE: 1
 
 production:
     variables:
@@ -52,7 +53,7 @@ production:
         K8S_SECRET_TOKEN_AUTH_ACCEPTED_AUDIENCE: "https://api.hel.fi/auth/helsinkiprofile"
         K8S_SECRET_TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX: "helsinkiprofile"
         K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://api.hel.fi/sso/openid"
-        K8S_SECRET_TOKEN_AUTH_REQUIRE_SCOPE: "True"
+        K8S_SECRET_TOKEN_AUTH_REQUIRE_SCOPE: 1
         K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
         K8S_SECRET_MAIL_MAILGUN_KEY: "$GL_MAILGUN_API_KEY"
         K8S_SECRET_MAIL_MAILGUN_DOMAIN: "mail.hel.ninja"
@@ -61,3 +62,11 @@ production:
         K8S_SECRET_DEFAULT_FROM_EMAIL: "no-reply@hel.ninja"
         K8S_SECRET_FIELD_ENCRYPTION_KEYS: "$GL_STABLE_FIELD_ENCRYPTION_KEYS"
         K8S_SECRET_FORCE_SCRIPT_NAME: "/profiili"
+        K8S_SECRET_MEDIA_URL: "/profiili/media/"
+        K8S_SECRET_STATIC_URL: "/profiili/static/"
+        K8S_SECRET_CSRF_COOKIE_NAME: "profiili-prod-csrftoken"
+        K8S_SECRET_CSRF_COOKIE_PATH: "/profiili/"
+        K8S_SECRET_CSRF_COOKIE_SECURE: 1
+        K8S_SECRET_SESSION_COOKIE_NAME: "profiili-prod-sessionid"
+        K8S_SECRET_SESSION_COOKIE_PATH: "/profiili/"
+        K8S_SECRET_SESSION_COOKIE_SECURE: 1

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -47,6 +47,12 @@ env = environ.Env(
     GDPR_API_ENABLED=(bool, False),
     ENABLE_GRAPHIQL=(bool, False),
     FORCE_SCRIPT_NAME=(str, ""),
+    CSRF_COOKIE_NAME=(str, ""),
+    CSRF_COOKIE_PATH=(str, ""),
+    CSRF_COOKIE_SECURE=(bool, None),
+    SESSION_COOKIE_NAME=(str, ""),
+    SESSION_COOKIE_PATH=(str, ""),
+    SESSION_COOKIE_SECURE=(bool, None),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -75,7 +81,24 @@ if DEBUG and not SECRET_KEY:
     SECRET_KEY = "xxx"
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
-SESSION_COOKIE_SECURE = False if DEBUG else True
+
+if env("CSRF_COOKIE_NAME"):
+    CSRF_COOKIE_NAME = env.str("CSRF_COOKIE_NAME")
+
+if env("CSRF_COOKIE_PATH"):
+    CSRF_COOKIE_PATH = env.str("CSRF_COOKIE_PATH")
+
+if env("CSRF_COOKIE_SECURE") is not None:
+    CSRF_COOKIE_SECURE = env.bool("CSRF_COOKIE_SECURE")
+
+if env("SESSION_COOKIE_NAME"):
+    SESSION_COOKIE_NAME = env.str("SESSION_COOKIE_NAME")
+
+if env("SESSION_COOKIE_PATH"):
+    SESSION_COOKIE_PATH = env.str("SESSION_COOKIE_PATH")
+
+if env("SESSION_COOKIE_SECURE") is not None:
+    SESSION_COOKIE_SECURE = env.bool("SESSION_COOKIE_SECURE")
 
 DATABASES = {"default": env.db()}
 # Ensure postgis engine


### PR DESCRIPTION
Added environment variables and production configurations so that we
can get the production environment working under the path /profiili,
as it's going to be used with api.hel.fi.