### PR TITLE
Add configuration for USE_X_FORWARDED_HOST via environment variables

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,3 +70,4 @@ production:
         K8S_SECRET_SESSION_COOKIE_NAME: "profiili-prod-sessionid"
         K8S_SECRET_SESSION_COOKIE_PATH: "/profiili/"
         K8S_SECRET_SESSION_COOKIE_SECURE: 1
+        K8S_SECRET_USE_X_FORWARDED_HOST: 1

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -53,6 +53,7 @@ env = environ.Env(
     SESSION_COOKIE_NAME=(str, ""),
     SESSION_COOKIE_PATH=(str, ""),
     SESSION_COOKIE_SECURE=(bool, None),
+    USE_X_FORWARDED_HOST=(bool, None),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -99,6 +100,9 @@ if env("SESSION_COOKIE_PATH"):
 
 if env("SESSION_COOKIE_SECURE") is not None:
     SESSION_COOKIE_SECURE = env.bool("SESSION_COOKIE_SECURE")
+
+if env("USE_X_FORWARDED_HOST") is not None:
+    USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST")
 
 DATABASES = {"default": env.db()}
 # Ensure postgis engine


### PR DESCRIPTION
Made it possible to configure USE_X_FORWARDED_HOST using environment
variables + enabled the setting in production.