### PR TITLE
OM-785 | Seeding development data generates youth profiles consistently

### DIFF
--- a/utils/management/commands/seed_data.py
+++ b/utils/management/commands/seed_data.py
@@ -12,6 +12,7 @@ from utils.utils import (
     generate_groups_for_services,
     generate_notifications,
     generate_profiles,
+    generate_service_connections,
     generate_services,
     generate_youth_profiles,
 )
@@ -128,9 +129,11 @@ class Command(BaseCommand):
             with factory.Faker.override_default_locale(locale):
                 self.stdout.write("Generating group admins...")
                 generate_group_admins(groups=groups, faker=faker)
-                self.stdout.write("Generating profiles ({})...".format(profile_count))
+                self.stdout.write(f"Generating profiles ({profile_count})...")
                 generate_profiles(profile_count, faker=faker)
+                self.stdout.write("Generating service connections...")
+                generate_service_connections(youth_profile_percentage)
                 self.stdout.write("Generating youth profiles...")
-                generate_youth_profiles(youth_profile_percentage, faker=faker)
+                generate_youth_profiles(faker=faker)
 
             self.stdout.write(self.style.SUCCESS("Done - Development fake data"))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -246,18 +246,34 @@ def generate_profiles(k=50, faker=None):
             country_code=faker.country_code(),
             address_type=AddressType.NONE,
         )
-        services = Service.objects.all()
-        if services.exists():
+
+
+def generate_service_connections(youth_profile_percentage=0.2):
+    """Create fake service connections for development purposes."""
+    profiles = Profile.objects.all()
+    number_of_youth_profiles_to_generate = int(
+        profiles.count() * youth_profile_percentage
+    )
+
+    youth_service = Service.objects.get(service_type=ServiceType.YOUTH_MEMBERSHIP)
+    other_services = Service.objects.exclude(pk=youth_service.pk)
+
+    for index, profile in enumerate(profiles):
+        if index < number_of_youth_profiles_to_generate:
+            ServiceConnection.objects.create(profile=profile, service=youth_service)
+        else:
             ServiceConnection.objects.create(
-                profile=profile, service=random.choice(services)
+                profile=profile, service=random.choice(other_services)
             )
 
 
-def generate_youth_profiles(percentage=0.2, faker=None):
+def generate_youth_profiles(faker=None):
     """Create fake youth membership profiles for development purposes."""
-    profiles = Profile.objects.all()
-    youth_profile_profiles = profiles.order_by("?")[: int(len(profiles) * percentage)]
-    for profile in youth_profile_profiles:
+    profiles = Profile.objects.filter(
+        service_connections__service__service_type=ServiceType.YOUTH_MEMBERSHIP
+    )
+
+    for profile in profiles:
         approved = bool(random.getrandbits(1))
         YouthProfile.objects.create(
             profile=profile,


### PR DESCRIPTION
Previously profiles with a youth membership service connections didn't necessarily get the actual youth membership profile generated for them.