### PR TITLE
OM-864 | GraphQL API requires authorization code for using GDPR related APIs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,7 @@ review:
         K8S_SECRET_DEFAULT_FROM_EMAIL: "no-reply@hel.ninja"
         K8S_SECRET_ENABLE_GRAPHIQL: 1
         K8S_SECRET_SEED_DEVELOPMENT_DATA: 1
+        K8S_SECRET_GDPR_API_ENABLED: 1
 
 staging:
     only:

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -732,6 +732,15 @@ class ClaimProfileMutation(relay.ClientIDMutation):
 
 
 class DeleteMyProfileMutation(relay.ClientIDMutation):
+    class Input:
+        authorization_code = graphene.String(
+            required=True,
+            description=(
+                "OAuth/OIDC authoziation code. When obtaining the code, it is required to use "
+                "service and operation specific GDPR API scopes."
+            ),
+        )
+
     @classmethod
     @login_required
     def mutate_and_get_payload(cls, root, info, **input):
@@ -791,8 +800,15 @@ class Query(graphene.ObjectType):
     # TODO: Change the description when the download API is implemented to fetch data from services as well
     # TODO: Add the complete list of error codes
     download_my_profile = graphene.JSONString(
+        authorization_code=graphene.String(
+            required=True,
+            description=(
+                "OAuth/OIDC authoziation code. When obtaining the code, it is required to use "
+                "service and operation specific GDPR API scopes."
+            ),
+        ),
         description="Get the user information stored in the profile as machine readable JSON.\n\nRequires "
-        "authentication.\n\nPossible error codes:\n\n* `TODO`"
+        "authentication.\n\nPossible error codes:\n\n* `TODO`",
     )
     # TODO: Add the complete list of error codes
     profiles = DjangoFilterConnectionField(

--- a/profiles/tests/test_profiles_graphql_gdpr_api.py
+++ b/profiles/tests/test_profiles_graphql_gdpr_api.py
@@ -21,7 +21,7 @@ GDPR_URL = "https://example.com/"
 
 DELETE_MY_PROFILE_MUTATION = """
     mutation {
-        deleteMyProfile(input: {}) {
+        deleteMyProfile(input: {authorizationCode: "code123"}) {
             clientMutationId
         }
     }
@@ -36,7 +36,7 @@ def test_user_can_download_profile(rf, user_gql_client):
 
     query = """
         {
-            downloadMyProfile
+            downloadMyProfile(authorizationCode: "code123")
         }
     """
     expected_json = json.dumps(


### PR DESCRIPTION
Add a required authorization code argument for queries and mutations related to using a GDPR API. Authorization code used by the backend for finishing up a OAuth/OIDC authorization code flow.

**NOTE!** This is a breaking change since it adds a required argument to the GQL API. Frontend work for providing the required authorization code is ticket OM-871.