### PR TITLE
Fix default value for youth membership expiration calculation

### DIFF
--- a/youths/models.py
+++ b/youths/models.py
@@ -15,12 +15,15 @@ from .enums import NotificationType
 from .enums import YouthLanguage as LanguageAtHome
 
 
-def calculate_expiration(from_date=date.today()):
+def calculate_expiration(from_date=None):
     """Calculates the expiration date for a youth membership based on the given date.
 
     Membership always expires at the end of the season. Signups made before the long season start month
     expire in the summer of the same year, others next year.
     """
+    if from_date is None:
+        from_date = date.today()
+
     full_season_start = settings.YOUTH_MEMBERSHIP_FULL_SEASON_START_MONTH
     expiration_day, expiration_month = settings.YOUTH_MEMBERSHIP_SEASON_END_DATE
     expiration_year = (

--- a/youths/tests/test_youth_profiles_graphql_api.py
+++ b/youths/tests/test_youth_profiles_graphql_api.py
@@ -1265,7 +1265,7 @@ def test_should_not_be_able_to_renew_pending_youth_profile(rf, user_gql_client):
     request.user = user_gql_client.user
     profile = ProfileFactory(user=user_gql_client.user)
 
-    with freeze_time("2020-04-30"):
+    with freeze_time("2020-05-15"):
         today = date.today()
         YouthProfileFactory(
             profile=profile,
@@ -1302,9 +1302,6 @@ def test_should_not_be_able_to_renew_pending_youth_profile(rf, user_gql_client):
             }
         """
         executed = user_gql_client.execute(mutation, context=request)
-        expected_data = {
-            "renewMyYouthProfile": {"youthProfile": {"membershipStatus": "ACTIVE"}}
-        }
         assert (
             executed["errors"][0].get("extensions").get("code")
             == CANNOT_RENEW_YOUTH_PROFILE_ERROR


### PR DESCRIPTION
The default value was initialized only once at function definition time.
All calls to the function would have reused the result of that definition-time
function call.