### PR TITLE
Mark count fields on ProfileConnection as required

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -168,8 +168,8 @@ class ProfilesConnection(graphene.Connection):
     class Meta:
         abstract = True
 
-    count = graphene.Int()
-    total_count = graphene.Int()
+    count = graphene.Int(required=True)
+    total_count = graphene.Int(required=True)
 
     def resolve_count(self, info):
         return self.length

--- a/profiles/tests/test_profiles_graphql_api.py
+++ b/profiles/tests/test_profiles_graphql_api.py
@@ -3139,6 +3139,25 @@ def test_profile_node_exposes_key_for_federation_gateway(rf, anon_user_gql_clien
     )
 
 
+def test_profile_connection_schema_matches_federated_schema(rf, anon_user_gql_client):
+    request = rf.post("/graphql")
+
+    query = """
+        query {
+            _service {
+                sdl
+            }
+        }
+    """
+
+    executed = anon_user_gql_client.execute(query, context=request)
+    assert (
+        "type ProfileNodeConnection {   pageInfo: PageInfo!   "
+        "edges: [ProfileNodeEdge]!   count: Int!   totalCount: Int! }"
+        in executed["data"]["_service"]["sdl"]
+    )
+
+
 def test_can_query_claimable_profile_with_token(rf, user_gql_client):
     profile = ProfileFactory(user=None, first_name="John", last_name="Doe")
     claim_token = ClaimTokenFactory(profile=profile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ ecdsa==0.13.3             # via python-jose
 et-xmlfile==1.0.1         # via openpyxl
 future==0.17.1            # via pyjwkest, python-jose
 graphene-django==2.10.1   # via -r requirements.in, django-graphql-jwt
-graphene-federation==0.0.4  # via -r requirements.in
+graphene-federation==0.1.0  # via -r requirements.in
 graphene==2.1.8           # via graphene-django, graphene-federation
 graphql-core==2.2.1       # via django-graphql-jwt, graphene, graphene-django, graphql-relay
 graphql-relay==2.0.0      # via graphene


### PR DESCRIPTION
These fields are non-nullable by themselves, since if there are
no errors, they will always have some integer value, and if there
are errors either the entire connection will be 'null' or single
nodes on that connection.

Venepaikka also has these as non-nullable and in order to federate
the schemas between our two services all the fields should have
the same scalar types.