### PR TITLE
Fix editing youth profile's additional contact persons

### DIFF
--- a/youths/tests/test_graphql_api_additional_contact_persons.py
+++ b/youths/tests/test_graphql_api_additional_contact_persons.py
@@ -84,7 +84,13 @@ def test_normal_user_can_remove_additional_contact_persons(
     request.user = user_gql_client.user
 
     variables = {
-        "input": {"youthProfile": {"removeAdditionalContactPersons": [str(acp.id)]}}
+        "input": {
+            "youthProfile": {
+                "removeAdditionalContactPersons": [
+                    to_global_id(type="AdditionalContactPersonNode", id=acp.pk)
+                ]
+            }
+        }
     }
     executed = user_gql_client.execute(
         UPDATE_MUTATION, context=request, variables=variables
@@ -111,7 +117,14 @@ def test_normal_user_can_update_additional_contact_persons(
     variables = {
         "input": {
             "youthProfile": {
-                "updateAdditionalContactPersons": [{"id": str(acp.id), **new_values}],
+                "updateAdditionalContactPersons": [
+                    {
+                        "id": to_global_id(
+                            type="AdditionalContactPersonNode", id=acp.pk
+                        ),
+                        **new_values,
+                    }
+                ],
             }
         }
     }

--- a/youths/utils.py
+++ b/youths/utils.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 from django.core.exceptions import ValidationError
+from graphql_relay import from_global_id
 
 from open_city_profile.exceptions import InvalidEmailFormatError
 from youths.models import AdditionalContactPerson, YouthProfile
@@ -17,9 +18,10 @@ def calculate_age(birth_date):
 
 def create_or_update_contact_persons(youth_profile: YouthProfile, data):
     for data_input in filter(None, data):
-        acp_id = data_input.pop("id", None)
-        if acp_id:
+        acp_global_id = data_input.pop("id", None)
+        if acp_global_id:
             # id is required on update input
+            acp_id = from_global_id(acp_global_id)[1]
             item = AdditionalContactPerson.objects.get(
                 youth_profile=youth_profile, pk=acp_id
             )
@@ -39,7 +41,8 @@ def create_or_update_contact_persons(youth_profile: YouthProfile, data):
 
 
 def delete_contact_persons(youth_profile: YouthProfile, data):
-    for remove_id in filter(None, data):
+    for remove_global_id in filter(None, data):
+        remove_id = from_global_id(remove_global_id)[1]
         AdditionalContactPerson.objects.get(
             youth_profile=youth_profile, pk=remove_id
         ).delete()


### PR DESCRIPTION
Updating or removing additional contact persons assumed the id to be an integer instead of a global identifier used by relay.