### PR TITLE
OM-903 | Hotfix: Allow deleting youth profile even when its GDPR API is disabled

### DIFF
--- a/profiles/tests/test_models.py
+++ b/profiles/tests/test_models.py
@@ -138,11 +138,11 @@ def test_remove_service_gdpr_data_successful(profile, service, requests_mock):
 
     service_connection = ServiceConnectionFactory(profile=profile, service=service)
 
-    dry_run = service_connection.delete_gdpr_data(dry_run=True)
-    real = service_connection.delete_gdpr_data()
+    dry_run_ok = service_connection.delete_gdpr_data(dry_run=True)
+    real_ok = service_connection.delete_gdpr_data()
 
-    assert dry_run.status_code == 204
-    assert real.status_code == 204
+    assert dry_run_ok
+    assert real_ok
 
 
 @pytest.mark.parametrize("service__gdpr_url", [GDPR_URL])

--- a/services/models.py
+++ b/services/models.py
@@ -2,6 +2,7 @@ import urllib.parse
 
 import requests
 from adminsortable.models import SortableMixin
+from django.conf import settings
 from django.db import models
 from django.db.models import Max
 from enumfields import EnumField
@@ -116,11 +117,21 @@ class ServiceConnection(SerializableMixin):
         if dry_run:
             data["dry_run"] = True
 
+        if (
+            not self.service.gdpr_url
+            and self.service.service_type == ServiceType.YOUTH_MEMBERSHIP
+            and not settings.GDPR_API_ENABLED
+        ):
+            # TODO Remove once youth profile is separated from profile OM-278
+            # If GDPR API for youth profile is disabled, we can still go ahead and
+            # say it's deletable. Youth profile is deleted when the profile is deleted.
+            return True
+
         if self.service.gdpr_url:
             url = urllib.parse.urljoin(self.service.gdpr_url, str(self.profile.pk))
             response = requests.delete(url, timeout=5, data=data)
             response.raise_for_status()
-            return response
+            return True
 
         raise MissingGDPRUrlException(
             f"Service {self.service.service_type.name} does not define an URL for GDPR removal."


### PR DESCRIPTION
Only allow this "override" when GDPR API url hasn't been defined for the youth membership service.