### PR TITLE
Clear thread locals after request

### DIFF
--- a/profiles/log_signals.py
+++ b/profiles/log_signals.py
@@ -77,7 +77,7 @@ def log(action, instance):
 
         service = get_current_service()
         if service:
-            message["profile_event"]["actor_service"] = {
+            message["audit_event"]["actor_service"] = {
                 "id": str(service.name),
                 "name": str(service.label),
             }

--- a/profiles/middleware.py
+++ b/profiles/middleware.py
@@ -1,8 +1,12 @@
 from django.utils.deprecation import MiddlewareMixin
 
-from .utils import set_current_user
+from .utils import clear_thread_locals, set_current_user
 
 
 class SetUser(MiddlewareMixin):
     def process_request(self, request):
         set_current_user(getattr(request, "user", None))
+
+    def process_response(self, request, response):
+        clear_thread_locals()
+        return response

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -56,6 +56,10 @@ def set_current_user(user):
     _thread_locals.user = user
 
 
+def clear_thread_locals():
+    _thread_locals.__dict__.clear()
+
+
 def set_current_service(service):
     _thread_locals.service = service
 


### PR DESCRIPTION
Attempt to fix failing user and service entries in audit log by clearing thread locals after each request 