### PR TITLE
YM-180 | Allow changing additional contact persons when approving a youth profile

### DIFF
--- a/youths/schema.py
+++ b/youths/schema.py
@@ -417,10 +417,23 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
         youth_data = input.get("approval_data")
         token = input.get("approval_token")
 
+        contact_persons_to_create = youth_data.pop("add_additional_contact_persons", [])
+        contact_persons_to_update = youth_data.pop(
+            "update_additional_contact_persons", []
+        )
+        contact_persons_to_delete = youth_data.pop(
+            "remove_additional_contact_persons", []
+        )
+
         youth_profile = YouthProfile.objects.get(approval_token=token)
 
         for field, value in youth_data.items():
             setattr(youth_profile, field, value)
+
+        # Additional contact persons
+        create_or_update_contact_persons(youth_profile, contact_persons_to_create)
+        create_or_update_contact_persons(youth_profile, contact_persons_to_update)
+        delete_contact_persons(youth_profile, contact_persons_to_delete)
 
         try:
             email = youth_profile.profile.get_primary_email()

--- a/youths/tests/test_graphql_api_additional_contact_persons.py
+++ b/youths/tests/test_graphql_api_additional_contact_persons.py
@@ -2,7 +2,7 @@ from string import Template
 
 from graphql_relay import to_global_id
 
-from profiles.tests.factories import ProfileFactory
+from profiles.tests.factories import EmailFactory, ProfileFactory
 from youths.models import AdditionalContactPerson
 from youths.tests.factories import (
     AdditionalContactPersonDictFactory,
@@ -33,6 +33,15 @@ UPDATE_MUTATION = Template(
     """
     mutation UpdateMyYouthProfile($$input: UpdateMyYouthProfileMutationInput!) {
         updateMyYouthProfile(input: $$input) ${query}
+    }
+    """
+).substitute(query=ADDITIONAL_CONTACT_PERSONS_QUERY)
+
+
+APPROVAL_MUTATION = Template(
+    """
+    mutation UpdateMyYouthProfile($$input: ApproveYouthProfileMutationInput!) {
+        approveYouthProfile(input: $$input) ${query}
     }
     """
 ).substitute(query=ADDITIONAL_CONTACT_PERSONS_QUERY)
@@ -186,3 +195,51 @@ def test_normal_user_can_query_additional_contact_persons(
         }
     }
     assert dict(executed["data"]) == expected_data
+
+
+def test_profile_approval_allows_changing_contact_persons(
+    rf, anon_user_gql_client, youth_profile
+):
+    EmailFactory(primary=True, profile=youth_profile.profile)
+
+    request = rf.post("/graphql")
+    request.user = anon_user_gql_client.user
+
+    acp_new_data = AdditionalContactPersonDictFactory()
+    acp_update = AdditionalContactPersonFactory(youth_profile=youth_profile)
+    acp_update_values = AdditionalContactPersonDictFactory()
+    acp_remove = AdditionalContactPersonFactory(youth_profile=youth_profile)
+
+    variables = {
+        "input": {
+            "approvalToken": youth_profile.approval_token,
+            "approvalData": {
+                "addAdditionalContactPersons": [acp_new_data],
+                "updateAdditionalContactPersons": [
+                    {
+                        "id": to_global_id(
+                            type="AdditionalContactPersonNode", id=acp_update.pk
+                        ),
+                        **acp_update_values,
+                    }
+                ],
+                "removeAdditionalContactPersons": [
+                    to_global_id(type="AdditionalContactPersonNode", id=acp_remove.pk)
+                ],
+            },
+        }
+    }
+
+    anon_user_gql_client.execute(
+        APPROVAL_MUTATION, context=request, variables=variables
+    )
+
+    assert not youth_profile.additional_contact_persons.filter(
+        pk=acp_remove.pk
+    ).exists()
+    assert youth_profile.additional_contact_persons.filter(
+        pk=acp_update.pk, first_name=acp_update_values["firstName"]
+    ).exists()
+    assert youth_profile.additional_contact_persons.exclude(
+        pk__in=[acp_update.pk, acp_remove.pk]
+    ).exists()


### PR DESCRIPTION
This PR adds the possibility to edit additional contact persons when approving a youth profile.