### PR TITLE
OM-927 | Don't ignore disabled service connection

### DIFF
--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -80,7 +80,7 @@ def user_has_staff_perms_to_view_profile(
     for any service connected to the passed profile.
     """
 
-    service_conns = profile.service_connections.filter(enabled=True)
+    service_conns = profile.service_connections.all()
     return any(
         [
             user.has_perm("can_view_profiles", service_conn.service)


### PR DESCRIPTION
Fixes failing permission check for profiles with disabled service connection