### PR TITLE
Update drf-oidc-auth -> 0.10, fixing a bug breaking Keycloak compatibility

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ django-reversion
 django-searchable-encrypted-fields
 django-thesaurus>=0.0.2
 djangorestframework
-drf-oidc-auth==0.9
+drf-oidc-auth==0.10.0
 graphene-django>=2.10.1
 graphene-federation
 pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,7 @@ djangorestframework==3.10.1
     #   -r requirements.in
     #   django-parler-rest
     #   drf-oidc-auth
-drf-oidc-auth==0.9
+drf-oidc-auth==0.10.0
     # via -r requirements.in
 ecdsa==0.13.3
     # via python-jose


### PR DESCRIPTION
drf-oidc-auth had a bug whereby it tried to compare 'azp' claim against allowed audiences. This is wrong as azp identifies the authorized party, not the resource provider who is identified by audience.

It should be noted that this changes internal caching implementation from a self baked, to one provided by Django. Per django documentation:

https://docs.djangoproject.com/en/3.1/topics/cache/, 

users should not need to change anything in config. Default in-memory cache will be used. Caching is used to store the public keys of OP, which are used to verify the incoming token. Therefore a failure in caching could cause a HTTP call
to Tunnistamo for every single incoming request. This should be allowed to stew in testing for some time.

Also django-helusers has a bug with the settings passed to drf-oidc-auth, but this masks it for time being.