### PR TITLE
Make temporary token generation delete valid token only for current profile

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -818,7 +818,7 @@ class CreateMyProfileTemporaryReadAccessTokenMutation(relay.ClientIDMutation):
         profile = Profile.objects.get(user=info.context.user)
 
         TemporaryReadAccessToken.objects.filter(
-            created_at__gt=timezone.now() - F("validity_duration")
+            profile=profile, created_at__gt=timezone.now() - F("validity_duration")
         ).delete()
 
         token = TemporaryReadAccessToken.objects.create(profile=profile)

--- a/profiles/tests/test_profiles_graphql_api.py
+++ b/profiles/tests/test_profiles_graphql_api.py
@@ -3436,6 +3436,7 @@ class TestTemporaryProfileReadAccessTokenCreation(
 
         valid_token1 = TemporaryReadAccessTokenFactory(profile=profile)
         valid_token2 = TemporaryReadAccessTokenFactory(profile=profile)
+        valid_token_for_another_profile = TemporaryReadAccessTokenFactory()
         expired_token = self.create_expired_token(profile)
 
         executed = user_gql_client.execute(self.query, context=request)
@@ -3452,6 +3453,7 @@ class TestTemporaryProfileReadAccessTokenCreation(
         assert not token_exists(valid_token2)
         assert token_exists(expired_token)
         assert token_exists(new_token_uuid)
+        assert token_exists(valid_token_for_another_profile)
 
 
 class TestTemporaryProfileReadAccessToken(TemporaryProfileReadAccessTokenTestBase):


### PR DESCRIPTION
This PR fixes an issue where generating a temporary token would delete valid tokens for all profiles.

Refs HP-59