### PR TITLE
Document that requirements need to be updated within container

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ The project is now running at [localhost:8000](http://localhost:8000)
 
 ## Keeping Python requirements up to date
 
+This repository contains `requirements*.in` and corresponding `requirements*.txt` files for requirements handling. The `requirements*.txt` files are generated from the `requirements*.in` files with `pip-compile`.
+
 1. Install `pip-tools`:
     * `pip install pip-tools`
 
@@ -159,6 +161,7 @@ The project is now running at [localhost:8000](http://localhost:8000)
 3. Update `.txt` file for the changed requirements file:
     * `pip-compile requirements.in`
     * `pip-compile requirements-dev.in`
+    * **Note:** the `requirements*.txt` files added to version control are meant to be used in the containerized environment where the service is run. Because [Python package dependencies are environment dependent](https://github.com/jazzband/pip-tools/#cross-environment-usage-of-requirementsinrequirementstxt-and-pip-compile) they need to be generated within a similar environment. This can be done by running the `pip-compile` command within Docker, for example like this: `docker-compose exec django pip-compile requirements.in` ([the container needs to be running](#development-with-docker) beforehand).
 
 4. If you want to update dependencies to their newest versions, run:
     * `pip-compile --upgrade requirements.in`


### PR DESCRIPTION
The `requirements*.txt` files are meant to be used in the containerized environment. Because Python package dependencies are environment dependent, they need to be generated within a container environment.