### PR TITLE
OM-863 | Store OIDC callback/redirect URI for GDPR API authentication

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,7 @@ review:
         K8S_SECRET_FIELD_ENCRYPTION_KEYS: "$GL_REVIEW_FIELD_ENCRYPTION_KEYS"
         K8S_SECRET_ENABLE_GRAPHIQL: 1
         K8S_SECRET_SEED_DEVELOPMENT_DATA: 1
+        K8S_SECRET_GDPR_AUTH_CALLBACK_URL: "https://profiili.test.kuva.hel.ninja/gdpr-callback"
 
 staging:
     only:
@@ -54,6 +55,7 @@ staging:
         K8S_SECRET_FIELD_ENCRYPTION_KEYS: "$GL_QA_FIELD_ENCRYPTION_KEYS"
         K8S_SECRET_ENABLE_GRAPHIQL: 1
         K8S_SECRET_SESSION_COOKIE_SECURE: 1
+        K8S_SECRET_GDPR_AUTH_CALLBACK_URL: "https://profiili.test.kuva.hel.ninja/gdpr-callback"
 
 production:
     variables:
@@ -85,3 +87,4 @@ production:
         K8S_SECRET_SESSION_COOKIE_SECURE: 1
         K8S_SECRET_USE_X_FORWARDED_HOST: 1
         K8S_SECRET_CSRF_TRUSTED_ORIGINS: "api.hel.fi"
+        K8S_SECRET_GDPR_AUTH_CALLBACK_URL: "https://profiili.hel.fi/gdpr-callback"

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -57,6 +57,7 @@ env = environ.Env(
     USE_X_FORWARDED_HOST=(bool, None),
     CSRF_TRUSTED_ORIGINS=(list, []),
     TEMPORARY_PROFILE_READ_ACCESS_TOKEN_VALIDITY_MINUTES=(int, 2 * 24 * 60),
+    GDPR_AUTH_CALLBACK_URL=(str, ""),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -319,3 +320,5 @@ LOGGING = {
     },
     "loggers": {"audit": {"handlers": ["audit"], "level": "INFO", "propagate": True}},
 }
+
+GDPR_AUTH_CALLBACK_URL = env("GDPR_AUTH_CALLBACK_URL")


### PR DESCRIPTION
This PR adds environment and configuration variable for storing the callback URI related to the GDPR API's OIDC authorization code retrieval. Backend needs this URI when exchanging the authorization code into an access token.