### PR TITLE
Use dataloader to resolve emails

### DIFF
--- a/profiles/loaders.py
+++ b/profiles/loaders.py
@@ -1,0 +1,16 @@
+from collections import defaultdict
+
+from promise import Promise
+from promise.dataloader import DataLoader
+
+from profiles.models import Email
+
+
+class EmailsByProfileIdLoader(DataLoader):
+    def batch_load_fn(self, profile_ids):
+        emails_by_profile_ids = defaultdict(list)
+        for email in Email.objects.filter(profile_id__in=profile_ids).iterator():
+            emails_by_profile_ids[email.profile_id].append(email)
+        return Promise.resolve(
+            [emails_by_profile_ids.get(profile_id, []) for profile_id in profile_ids]
+        )

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -399,7 +399,7 @@ class RestrictedProfileNode(DjangoObjectType):
         return Address.objects.filter(profile=self, primary=True).first()
 
     def resolve_emails(self, info, **kwargs):
-        return Email.objects.filter(profile=self)
+        return info.context.emails_by_profile_id_loader.load(self.id)
 
     def resolve_phones(self, info, **kwargs):
         return Phone.objects.filter(profile=self)


### PR DESCRIPTION
An example of using dataloader to resolve emails in a more efficient way. 
Source: https://apirobot.me/posts/django-graphql-solving-n-1-problem-using-dataloaders