### PR TITLE
Handle null inputs in verified personal information mutation

### DIFF
--- a/open_city_profile/tests/__init__.py
+++ b/open_city_profile/tests/__init__.py
@@ -1,0 +1,5 @@
+import inflection
+
+
+def to_graphql_name(s):
+    return inflection.camelize(s, False)

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -261,6 +261,22 @@ class VerifiedPersonalInformation(ValidateOnSaveModel):
             ),
         ]
 
+    def clean(self):
+        super().clean()
+
+        for field_name in [
+            "first_name",
+            "last_name",
+            "given_name",
+            "national_identification_number",
+            "email",
+            "municipality_of_residence",
+            "municipality_of_residence_number",
+        ]:
+            value = getattr(self, field_name)
+            if value is None:
+                setattr(self, field_name, "")
+
 
 class EncryptedAddress(ValidateOnSaveModel, UpdateMixin):
     street_address = fields.EncryptedCharField(max_length=1024, blank=True)

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -17,7 +17,13 @@ from open_city_profile.exceptions import ProfileMustHaveOnePrimaryEmail
 from services.enums import ServiceType
 from services.models import Service, ServiceConnection
 from users.models import User
-from utils.models import SerializableMixin, UpdateMixin, UUIDModel, ValidateOnSaveModel
+from utils.models import (
+    NullsToEmptyStringsModel,
+    SerializableMixin,
+    UpdateMixin,
+    UUIDModel,
+    ValidateOnSaveModel,
+)
 
 from .enums import (
     AddressType,
@@ -237,7 +243,7 @@ class Profile(UUIDModel, SerializableMixin):
         return result
 
 
-class VerifiedPersonalInformation(ValidateOnSaveModel):
+class VerifiedPersonalInformation(ValidateOnSaveModel, NullsToEmptyStringsModel):
     profile = models.OneToOneField(
         Profile, on_delete=models.CASCADE, related_name="verified_personal_information"
     )
@@ -261,24 +267,8 @@ class VerifiedPersonalInformation(ValidateOnSaveModel):
             ),
         ]
 
-    def clean(self):
-        super().clean()
 
-        for field_name in [
-            "first_name",
-            "last_name",
-            "given_name",
-            "national_identification_number",
-            "email",
-            "municipality_of_residence",
-            "municipality_of_residence_number",
-        ]:
-            value = getattr(self, field_name)
-            if value is None:
-                setattr(self, field_name, "")
-
-
-class EncryptedAddress(ValidateOnSaveModel, UpdateMixin):
+class EncryptedAddress(ValidateOnSaveModel, UpdateMixin, NullsToEmptyStringsModel):
     street_address = fields.EncryptedCharField(max_length=1024, blank=True)
     postal_code = fields.EncryptedCharField(max_length=1024, blank=True)
     post_office = fields.EncryptedCharField(max_length=1024, blank=True)
@@ -311,7 +301,7 @@ class VerifiedPersonalInformationTemporaryAddress(EncryptedAddress):
 
 
 class VerifiedPersonalInformationPermanentForeignAddress(
-    ValidateOnSaveModel, UpdateMixin
+    ValidateOnSaveModel, UpdateMixin, NullsToEmptyStringsModel
 ):
     RELATED_NAME = "permanent_foreign_address"
 

--- a/profiles/tests/test_profiles_graphql_api.py
+++ b/profiles/tests/test_profiles_graphql_api.py
@@ -2871,6 +2871,33 @@ class TestProfileWithVerifiedPersonalInformation:
             profile_with_verified_personal_information.user.uuid, rf, user_gql_client,
         )
 
+    def test_all_basic_fields_can_be_set_to_null(self, rf, user_gql_client):
+        input_data = {
+            "userId": "03117666-117D-4F6B-80B1-A3A92B389711",
+            "profile": {
+                "verifiedPersonalInformation": {
+                    "firstName": None,
+                    "lastName": None,
+                    "givenName": None,
+                    "nationalIdentificationNumber": None,
+                    "email": None,
+                    "municipalityOfResidence": None,
+                    "municipalityOfResidenceNumber": None,
+                },
+            },
+        }
+
+        profile = self.execute_successful_mutation(input_data, rf, user_gql_client)
+
+        verified_personal_information = profile.verified_personal_information
+        assert verified_personal_information.first_name == ""
+        assert verified_personal_information.last_name == ""
+        assert verified_personal_information.given_name == ""
+        assert verified_personal_information.national_identification_number == ""
+        assert verified_personal_information.email == ""
+        assert verified_personal_information.municipality_of_residence == ""
+        assert verified_personal_information.municipality_of_residence_number == ""
+
     @pytest.mark.parametrize(
         "address_type",
         ["permanent_address", "temporary_address", "permanent_foreign_address"],

--- a/profiles/tests/test_profiles_graphql_api.py
+++ b/profiles/tests/test_profiles_graphql_api.py
@@ -2982,13 +2982,8 @@ class TestProfileWithVerifiedPersonalInformation:
         verified_personal_information = profile.verified_personal_information
         address = getattr(verified_personal_information, address_type)
 
-        assert address.street_address == existing_address.street_address
-        if address_type == "permanent_foreign_address":
-            assert address.additional_address == existing_address.additional_address
-            assert address.country_code == existing_address.country_code
-        else:
-            assert address.postal_code == existing_address.postal_code
-            assert address.post_office == existing_address.post_office
+        for field_name in self.ADDRESS_FIELD_NAMES[address_type]:
+            assert getattr(address, field_name) == getattr(existing_address, field_name)
 
     @pytest.mark.parametrize(
         "address_type",

--- a/profiles/tests/test_profiles_graphql_api.py
+++ b/profiles/tests/test_profiles_graphql_api.py
@@ -2,7 +2,6 @@ import uuid
 from datetime import datetime, timedelta
 from string import Template
 
-import inflection
 import pytest
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
@@ -19,6 +18,7 @@ from open_city_profile.consts import (
     PROFILE_MUST_HAVE_ONE_PRIMARY_EMAIL,
     TOKEN_EXPIRED_ERROR,
 )
+from open_city_profile.tests import to_graphql_name
 from open_city_profile.tests.asserts import assert_almost_equal
 from open_city_profile.tests.factories import GroupFactory
 from profiles.enums import AddressType, EmailType, PhoneType
@@ -2940,7 +2940,7 @@ class TestProfileWithVerifiedPersonalInformation:
     ):
         user_id = profile.user.uuid
 
-        camel_case_address_type = inflection.camelize(address_type, False)
+        gql_address_type = to_graphql_name(address_type)
 
         address_fields = {}
         for name in address_field_names:
@@ -2949,9 +2949,7 @@ class TestProfileWithVerifiedPersonalInformation:
         input_data = {
             "userId": str(user_id),
             "profile": {
-                "verifiedPersonalInformation": {
-                    camel_case_address_type: address_fields,
-                },
+                "verifiedPersonalInformation": {gql_address_type: address_fields},
             },
         }
 

--- a/utils/models.py
+++ b/utils/models.py
@@ -142,3 +142,30 @@ class ValidateOnSaveModel(models.Model):
     def save(self, *args, **kwargs):
         self.full_clean()
         return super().save(*args, **kwargs)
+
+
+class NullsToEmptyStringsModel(models.Model):
+    """A Model that ensures that all of its string fields (e.g. CharField)
+    that are configured as not-null, have an empty string instead of a None
+    value. This verification happens in the clean() method."""
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def _non_nullable_string_field_names(cls):
+        if not hasattr(cls, "_cached_non_nullable_string_field_names"):
+            names = []
+            for field in cls._meta.fields:
+                if isinstance(field, models.CharField) and not field.null:
+                    names.append(field.attname)
+            setattr(cls, "_cached_non_nullable_string_field_names", names)
+        return cls._cached_non_nullable_string_field_names
+
+    def clean(self):
+        super().clean()
+
+        for field_name in self._non_nullable_string_field_names():
+            value = getattr(self, field_name)
+            if value is None:
+                setattr(self, field_name, "")


### PR DESCRIPTION
Previously I believed that `nulls` can't be provided as input to mutations with Graphene. That's indeed the case if one embeds the `nulls` directly inside the mutation like this:

```graphql
mutation {
  myMutation(
    input: {
      field: null
    },
  )
}
```

Graphene considers this as a syntax error and refuses to execute the operation at all.

But when using the placeholders+variables syntax of GraphQL it is indeed possible to provide `nulls` as input data. This PR handles `null` inputs for the `createOrUpdateProfileWithVerifiedPersonalInformation` mutation.