### PR TITLE
VEN-1072 | Add DataLoaders for performance

### DIFF
--- a/open_city_profile/middlewares.py
+++ b/open_city_profile/middlewares.py
@@ -1,0 +1,33 @@
+from profiles.loaders import (
+    AddressesByProfileIdLoader,
+    EmailsByProfileIdLoader,
+    PhonesByProfileIdLoader,
+    PrimaryAddressForProfileLoader,
+    PrimaryEmailForProfileLoader,
+    PrimaryPhoneForProfileLoader,
+)
+
+LOADERS = {
+    "addresses_by_profile_id_loader": AddressesByProfileIdLoader,
+    "emails_by_profile_id_loader": EmailsByProfileIdLoader,
+    "phones_by_profile_id_loader": PhonesByProfileIdLoader,
+    "primary_address_for_profile_loader": PrimaryAddressForProfileLoader,
+    "primary_email_for_profile_loader": PrimaryEmailForProfileLoader,
+    "primary_phone_for_profile_loader": PrimaryPhoneForProfileLoader,
+}
+
+
+class GQLDataLoaders:
+    def __init__(self):
+        self.cached_loaders = False
+
+    def resolve(self, next, root, info, **kwargs):
+        context = info.context
+
+        if not self.cached_loaders:
+            for loader_name, loader_class in LOADERS.items():
+                setattr(context, loader_name, loader_class())
+
+            self.cached_loaders = True
+
+        return next(root, info, **kwargs)

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -282,9 +282,12 @@ MAILER_EMAIL_BACKEND = env.str("MAILER_EMAIL_BACKEND")
 
 GRAPHENE = {
     "SCHEMA": "open_city_profile.schema.schema",
-    "MIDDLEWARE": ["open_city_profile.graphene.JWTMiddleware"]
-    if USE_HELUSERS_REQUEST_JWT_AUTH
-    else ["graphql_jwt.middleware.JSONWebTokenMiddleware"],
+    "MIDDLEWARE": [
+        "open_city_profile.graphene.JWTMiddleware"
+        if USE_HELUSERS_REQUEST_JWT_AUTH
+        else "graphql_jwt.middleware.JSONWebTokenMiddleware",
+        "open_city_profile.middlewares.GQLDataLoaders",
+    ],
 }
 
 if not USE_HELUSERS_REQUEST_JWT_AUTH:

--- a/open_city_profile/tests/conftest.py
+++ b/open_city_profile/tests/conftest.py
@@ -3,9 +3,10 @@ import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
 from django.core.management import call_command
-from graphene.test import Client as GraphQLClient
+from graphene.test import Client as GrapheneClient
 from graphql import build_client_schema, introspection_query
 
+from open_city_profile.middlewares import GQLDataLoaders
 from open_city_profile.schema import schema
 from open_city_profile.tests.factories import (
     GroupFactory,
@@ -13,6 +14,16 @@ from open_city_profile.tests.factories import (
     UserFactory,
 )
 from open_city_profile.views import GraphQLView
+
+
+class GraphQLClient(GrapheneClient):
+    def execute(self, *args, **kwargs):
+        """
+        Custom wrapper on the execute method, allows adding the
+        GQL DataLoaders middleware, since it has to be added to make
+        the DataLoaders available through the context.
+        """
+        return super().execute(*args, middleware=[GQLDataLoaders()], **kwargs)
 
 
 @pytest.fixture(autouse=True)

--- a/profiles/loaders.py
+++ b/profiles/loaders.py
@@ -1,0 +1,54 @@
+from collections import defaultdict
+
+from promise import Promise
+from promise.dataloader import DataLoader
+
+from profiles.models import Address, Email, Phone
+
+
+def loader_for_profile(model):
+    class BaseByProfileIdLoader(DataLoader):
+        def batch_load_fn(self, profile_ids):
+            items_by_profile_ids = defaultdict(list)
+            for item in model.objects.filter(profile_id__in=profile_ids).iterator():
+                items_by_profile_ids[item.profile_id].append(item)
+            return Promise.resolve(
+                [items_by_profile_ids.get(profile_id, []) for profile_id in profile_ids]
+            )
+
+    return BaseByProfileIdLoader
+
+
+def loader_for_profile_primary(model):
+    class BaseByProfileIdPrimaryLoader(DataLoader):
+        def batch_load_fn(self, profile_ids):
+            items_by_profile_ids = defaultdict()
+            for item in model.objects.filter(
+                profile_id__in=profile_ids, primary=True
+            ).iterator():
+                items_by_profile_ids[item.profile_id] = item
+
+            return Promise.resolve(
+                [items_by_profile_ids.get(profile_id) for profile_id in profile_ids]
+            )
+
+    return BaseByProfileIdPrimaryLoader
+
+
+EmailsByProfileIdLoader = loader_for_profile(Email)
+PhonesByProfileIdLoader = loader_for_profile(Phone)
+AddressesByProfileIdLoader = loader_for_profile(Address)
+
+PrimaryEmailForProfileLoader = loader_for_profile_primary(Email)
+PrimaryPhoneForProfileLoader = loader_for_profile_primary(Phone)
+PrimaryAddressForProfileLoader = loader_for_profile_primary(Address)
+
+
+__all__ = [
+    "AddressesByProfileIdLoader",
+    "EmailsByProfileIdLoader",
+    "PhonesByProfileIdLoader",
+    "PrimaryAddressForProfileLoader",
+    "PrimaryEmailForProfileLoader",
+    "PrimaryPhoneForProfileLoader",
+]


### PR DESCRIPTION
## Description :sparkles:
* Add dataloaders for `ProfileNode`: emails, addresses, phones, primary phone, primary email, primary address

## Issues :bug:
### Closes :no_good_woman:
**[VEN-1072](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1072):** Improve Profiili fetch loading times

### Related :handshake:
https://github.com/City-of-Helsinki/berth-reservations/pull/442

## Testing :alembic:
### Automated testing ⚙️ 
Run all the test suite
```shell
$ pytest
```

### Manual testing :construction_worker_man:
```graphql
query PROFILES {
  profiles(serviceType: BERTH) {
    edges {
      node {
        emails {
          edges {
            node {
              id
              email
              emailType
            }
          }
        }
        addresses {
          edges {
            node {
              id
              address
              city
              countryCode
              addressType
              postalCode
            }
          }
        }
        phones {
          edges {
            node {
              id
              phone
              phoneType
            }
          }
        }
        primaryEmail {
          id
          email
          emailType
        }
        primaryAddress {
          id
          address
          addressType
          postalCode
        }
        primaryPhone {
          id
          phone
          phoneType
        }
      }
    }
  }
}
```
