### PR TITLE
HP-398 Enable filtering profiles with ids

### DIFF
--- a/open_city_profile/graphene.py
+++ b/open_city_profile/graphene.py
@@ -1,3 +1,11 @@
+import uuid
+
+import graphene
+from django.forms import MultipleChoiceField
+from django_filters import MultipleChoiceFilter
+from graphene_django.forms.converter import convert_form_field
+
+
 class JWTMiddleware:
     def resolve(self, next, root, info, **kwargs):
         request = info.context
@@ -7,3 +15,23 @@ class JWTMiddleware:
             raise auth_error
 
         return next(root, info, **kwargs)
+
+
+class UUIDMultipleChoiceField(MultipleChoiceField):
+    def to_python(self, value):
+        if not value:
+            return []
+        # It's already a list of UUIDs, ensured and converted by Graphene
+        return value
+
+    def valid_value(self, value):
+        return isinstance(value, uuid.UUID)
+
+
+@convert_form_field.register(UUIDMultipleChoiceField)
+def convert_form_field_to_uuid_list(field):
+    return graphene.List(graphene.NonNull(graphene.UUID), required=field.required)
+
+
+class UUIDMultipleChoiceFilter(MultipleChoiceFilter):
+    field_class = UUIDMultipleChoiceField

--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -341,7 +341,7 @@ type Query {
   profile(id: ID!, serviceType: ServiceType!): ProfileNode
   myProfile: ProfileWithVerifiedPersonalInformationNode
   downloadMyProfile(authorizationCode: String!): JSONString
-  profiles(serviceType: ServiceType!, before: String, after: String, first: Int, last: Int, firstName: String, lastName: String, nickname: String, emails_Email: String, emails_EmailType: String, emails_Primary: Boolean, emails_Verified: Boolean, phones_Phone: String, phones_PhoneType: String, phones_Primary: Boolean, addresses_Address: String, addresses_PostalCode: String, addresses_City: String, addresses_CountryCode: String, addresses_AddressType: String, addresses_Primary: Boolean, language: String, enabledSubscriptions: String, orderBy: String): ProfileNodeConnection
+  profiles(serviceType: ServiceType!, before: String, after: String, first: Int, last: Int, id: [UUID!], firstName: String, lastName: String, nickname: String, emails_Email: String, emails_EmailType: String, emails_Primary: Boolean, emails_Verified: Boolean, phones_Phone: String, phones_PhoneType: String, phones_Primary: Boolean, addresses_Address: String, addresses_PostalCode: String, addresses_City: String, addresses_CountryCode: String, addresses_AddressType: String, addresses_Primary: Boolean, language: String, enabledSubscriptions: String, orderBy: String): ProfileNodeConnection
   claimableProfile(token: UUID!): ProfileNode
   profileWithAccessToken(token: UUID!): RestrictedProfileNode
   _entities(representations: [_Any]): [_Entity]

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -36,6 +36,7 @@ from open_city_profile.exceptions import (
     ProfileMustHaveOnePrimaryEmail,
     TokenExpiredError,
 )
+from open_city_profile.graphene import UUIDMultipleChoiceFilter
 from open_city_profile.oidc import TunnistamoTokenExchange
 from profiles.decorators import staff_required
 from services.exceptions import MissingGDPRUrlException
@@ -249,6 +250,7 @@ class ProfileFilter(FilterSet):
     class Meta:
         model = Profile
         fields = (
+            "id",
             "first_name",
             "last_name",
             "nickname",
@@ -269,6 +271,10 @@ class ProfileFilter(FilterSet):
             "enabled_subscriptions",
         )
 
+    id = UUIDMultipleChoiceFilter(
+        label="Profile ids for selecting the exact profiles to return. "
+        '**Note:** these are raw UUIDs, not "relay opaque identifiers".'
+    )
     first_name = CharFilter(lookup_expr="icontains")
     last_name = CharFilter(lookup_expr="icontains")
     nickname = CharFilter(lookup_expr="icontains")


### PR DESCRIPTION
The `profiles` GraphQL query got a new filtering option: `id`. A list of UUIDs can be provided to select only the wanted profiles.

Since a "list of UUIDs" is a type not directly supported by Graphene and/or django_filters, needed to implement some small classes to get the type of the new filtering argument correct.