### PR TITLE
HP-496 Show verified personal information in admin

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -21,6 +21,7 @@ from profiles.models import (
     Profile,
     SensitiveData,
     TemporaryReadAccessToken,
+    VerifiedPersonalInformation,
 )
 from services.admin import ServiceConnectionInline
 from subscriptions.admin import SubscriptionInline
@@ -108,6 +109,20 @@ class AddressAdminInline(admin.StackedInline):
     extra = 0
 
 
+class VerifiedPersonalInformationAdminInline(admin.StackedInline):
+    model = VerifiedPersonalInformation
+    extra = 0
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 class ImportProfilesFromJsonForm(forms.Form):
     json_file = forms.FileField(required=True, label="Please select a json file")
 
@@ -115,6 +130,7 @@ class ImportProfilesFromJsonForm(forms.Form):
 @admin.register(Profile)
 class ExtendedProfileAdmin(VersionAdmin):
     inlines = [
+        VerifiedPersonalInformationAdminInline,
         SensitiveDataAdminInline,
         RepresenteeAdmin,
         RepresentativeAdmin,

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -111,6 +111,11 @@ class AddressAdminInline(admin.StackedInline):
 
 class VerifiedPersonalInformationAdminInline(admin.StackedInline):
     model = VerifiedPersonalInformation
+    readonly_fields = (
+        "get_permanent_address",
+        "get_temporary_address",
+        "get_permanent_foreign_address",
+    )
     extra = 0
 
     def has_add_permission(self, request, obj=None):
@@ -121,6 +126,33 @@ class VerifiedPersonalInformationAdminInline(admin.StackedInline):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def get_permanent_address(self, obj):
+        return "{}, {} {}\n".format(
+            obj.permanent_address.street_address,
+            obj.permanent_address.postal_code,
+            obj.permanent_address.post_office,
+        )
+
+    get_permanent_address.short_description = "Permanent address"
+
+    def get_temporary_address(self, obj):
+        return "{}, {} {}\n".format(
+            obj.temporary_address.street_address,
+            obj.temporary_address.postal_code,
+            obj.temporary_address.post_office,
+        )
+
+    get_temporary_address.short_description = "Temporary address"
+
+    def get_permanent_foreign_address(self, obj):
+        return "{}, {}, {}\n".format(
+            obj.permanent_foreign_address.street_address,
+            obj.permanent_foreign_address.additional_address,
+            obj.permanent_foreign_address.country_code,
+        )
+
+    get_permanent_foreign_address.short_description = "Permanent foreign address"
 
 
 class ImportProfilesFromJsonForm(forms.Form):


### PR DESCRIPTION
Adds VerifiedPersonalInformation model as a Stacked Inline admin in Profile admin. No user has permission to add, change, or delete the values.

Should we consider audit logging here?