### PR TITLE
OM-931 | Increase the buffer-size for uWSGI

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -5,6 +5,7 @@ module = open_city_profile.wsgi
 static-map = /static=/app/static
 uid = nobody
 gid = nogroup
+buffer-size = 32768
 master = 1
 processes = 2
 threads = 2


### PR DESCRIPTION
This PR increases the buffer-size for uWSGI which will allow e.g. to include big lists of
AD-group memberships in a Bearer authentication token.

https://uwsgi-docs.readthedocs.io/en/latest/Options.html#buffer-size

Buffer size was chosen to be the same as in [berth-reservations](https://github.com/City-of-Helsinki/berth-reservations)

Refs OM-931