### PR TITLE
Fix audit log timestamps

### DIFF
--- a/open_city_profile/tests/asserts.py
+++ b/open_city_profile/tests/asserts.py
@@ -6,13 +6,21 @@ import pytest
 def assert_almost_equal(a, b, epsilon=None):
     __tracebackhide__ = True
 
-    if isinstance(a, datetime) and isinstance(b, datetime):
+    def _both_of_type(typ):
+        return isinstance(a, typ) and isinstance(b, typ)
+
+    def _absolute_delta_equality(default_epsilon):
         delta = abs(a - b)
-        epsilon = epsilon if epsilon is not None else timedelta(milliseconds=1)
-        if delta > epsilon:
+        eps = epsilon if epsilon is not None else default_epsilon
+        if delta > eps:
             pytest.fail(
-                f"{a} is not almost equal to {b} (difference {delta} is more than allowd {epsilon})"
+                f"{a} is not almost equal to {b} (difference {delta} is more than allowed {eps})"
             )
+
+    if _both_of_type(datetime):
+        _absolute_delta_equality(timedelta(milliseconds=1))
+    elif _both_of_type(int):
+        _absolute_delta_equality(1)
     else:
         raise NotImplementedError(
             f"assert_almost_equal not implemented for types {type(a)} and {type(b)}"

--- a/profiles/log_signals.py
+++ b/profiles/log_signals.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django.conf import settings
 from django.db.models.signals import post_delete, post_init, post_save
@@ -36,7 +36,7 @@ def log(action, instance):
     ):
         logger = logging.getLogger("audit")
 
-        current_time = datetime.utcnow()
+        current_time = datetime.now(tz=timezone.utc)
         current_user = get_current_user()
         profile = instance.resolve_profile()
         profile_id = str(profile.pk) if profile else None

--- a/profiles/log_signals.py
+++ b/profiles/log_signals.py
@@ -47,7 +47,7 @@ def log(action, instance):
                 "origin": "PROFILE-BE",
                 "status": "SUCCESS",
                 "date_time_epoch": int(current_time.timestamp()),
-                "date_time": f"{current_time.isoformat(sep='T', timespec='milliseconds')}Z",
+                "date_time": f"{current_time.replace(tzinfo=None).isoformat(sep='T', timespec='milliseconds')}Z",
                 "actor": {"role": _resolve_role(current_user, profile)},
                 "operation": action,
                 "target": {

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from django.conf import settings
@@ -40,7 +41,12 @@ def assert_common_fields(log_message, actor_role="SYSTEM"):
     assert log_message["audit_event"]["actor"]["role"] == actor_role
     now = get_unix_timestamp_now()
     assert_almost_equal(log_message["audit_event"]["date_time_epoch"], now)
-    assert log_message["audit_event"]["date_time"] is not None
+
+    now_dt = datetime.fromtimestamp(now, tz=timezone.utc)
+    log_dt = datetime.strptime(
+        log_message["audit_event"]["date_time"], "%Y-%m-%dT%H:%M:%S.%fZ"
+    ).replace(tzinfo=timezone.utc)
+    assert_almost_equal(log_dt, now_dt, timedelta(seconds=1))
 
 
 def test_audit_log_read(user, enable_audit_log, cap_audit_log):

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -4,6 +4,8 @@ import logging
 import pytest
 from django.conf import settings
 
+from open_city_profile.tests.asserts import assert_almost_equal
+from open_city_profile.tests.conftest import get_unix_timestamp_now
 from open_city_profile.tests.graphql_test_helpers import do_graphql_call_as_user
 from profiles.models import Profile
 
@@ -36,7 +38,8 @@ def assert_common_fields(log_message, actor_role="SYSTEM"):
     assert log_message["audit_event"]["origin"] == "PROFILE-BE"
     assert log_message["audit_event"]["status"] == "SUCCESS"
     assert log_message["audit_event"]["actor"]["role"] == actor_role
-    assert log_message["audit_event"]["date_time_epoch"] is not None
+    now = get_unix_timestamp_now()
+    assert_almost_equal(log_message["audit_event"]["date_time_epoch"], now)
     assert log_message["audit_event"]["date_time"] is not None
 
 


### PR DESCRIPTION
Local timezone was used for the unix timestamp, but it should always be presented in UTC.