### PR TITLE
Add caller's IP address to audit log

### DIFF
--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -59,6 +59,7 @@ env = environ.Env(
     SESSION_COOKIE_NAME=(str, ""),
     SESSION_COOKIE_PATH=(str, ""),
     SESSION_COOKIE_SECURE=(bool, None),
+    USE_X_FORWARDED_FOR=(bool, False),
     USE_X_FORWARDED_HOST=(bool, None),
     CSRF_TRUSTED_ORIGINS=(list, []),
     TEMPORARY_PROFILE_READ_ACCESS_TOKEN_VALIDITY_MINUTES=(int, 2 * 24 * 60),
@@ -110,6 +111,8 @@ if env("SESSION_COOKIE_PATH"):
 
 if env("SESSION_COOKIE_SECURE") is not None:
     SESSION_COOKIE_SECURE = env.bool("SESSION_COOKIE_SECURE")
+
+USE_X_FORWARDED_FOR = env.bool("USE_X_FORWARDED_FOR")
 
 if env("USE_X_FORWARDED_HOST") is not None:
     USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST")

--- a/open_city_profile/tests/settings.py
+++ b/open_city_profile/tests/settings.py
@@ -1,5 +1,7 @@
 from open_city_profile.settings import *  # noqa
 
+USE_X_FORWARDED_FOR = True
+
 OIDC_API_TOKEN_AUTH = {
     "AUDIENCE": "test_audience",
     "ISSUER": "https://test_issuer",

--- a/profiles/log_signals.py
+++ b/profiles/log_signals.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db.models.signals import post_delete, post_init, post_save
 from django.dispatch import receiver
 
-from .utils import get_current_service, get_current_user
+from .utils import get_current_service, get_current_user, get_original_client_ip
 
 
 def should_audit(model):
@@ -79,6 +79,13 @@ def log(action, instance):
                 "id": str(service.name),
                 "name": str(service.label),
             }
+
+        ip_address = get_original_client_ip()
+        if ip_address:
+            message["audit_event"]["profilebe"] = {
+                "ip_address": ip_address,
+            }
+
         logger.info(json.dumps(message))
 
 

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -132,14 +132,15 @@ def test_actor_is_resolved_in_graphql_call(
     assert log_message["audit_event"]["actor"]["user_name"] == user.username
 
 
+@pytest.mark.parametrize(
+    "header", ["12.23.34.45", "12.23.34.45,1.1.1.1", "12.23.34.45, 1.1.1.1"]
+)
 def test_requester_ip_address_is_extracted_from_x_forwarded_for_header(
-    enable_audit_log, live_server, profile, cap_audit_log
+    header, enable_audit_log, live_server, profile, cap_audit_log
 ):
     user = profile.user
 
-    ip_address = "12.23.34.45"
-
-    request_args = {"headers": {"X-Forwarded-For": ip_address}}
+    request_args = {"headers": {"X-Forwarded-For": header}}
 
     do_graphql_call_as_user(
         live_server, user, MY_PROFILE_QUERY, extra_request_args=request_args
@@ -147,4 +148,4 @@ def test_requester_ip_address_is_extracted_from_x_forwarded_for_header(
     audit_logs = cap_audit_log.get_logs()
     assert len(audit_logs) == 1
     log_message = audit_logs[0]
-    assert log_message["audit_event"]["profilebe"]["ip_address"] == ip_address
+    assert log_message["audit_event"]["profilebe"]["ip_address"] == "12.23.34.45"

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -158,6 +158,16 @@ class TestIPAddressLogging:
             live_server, profile, "12.23.34.45", cap_audit_log, request_args
         )
 
+    def test_do_not_use_x_forwarded_for_header_if_it_is_denied_in_settings(
+        self, enable_audit_log, live_server, settings, profile, cap_audit_log
+    ):
+        settings.USE_X_FORWARDED_FOR = False
+        request_args = {"headers": {"X-Forwarded-For": "should ignore"}}
+
+        self.execute_ip_address_test(
+            live_server, profile, "127.0.0.1", cap_audit_log, request_args
+        )
+
     def test_requester_ip_address_is_extracted_from_remote_addr_meta(
         self, enable_audit_log, live_server, profile, cap_audit_log
     ):

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -81,6 +81,9 @@ def get_original_client_ip():
         forwarded_for = request.headers.get("x-forwarded-for", "")
         client_ip = forwarded_for.split(",")[0] or None
 
+        if not client_ip:
+            client_ip = request.META.get("REMOTE_ADDR")
+
     return client_ip
 
 

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -1,6 +1,7 @@
 import threading
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from graphql_relay.node.node import from_global_id
 
@@ -78,8 +79,9 @@ def get_original_client_ip():
 
     request = get_current_request()
     if request:
-        forwarded_for = request.headers.get("x-forwarded-for", "")
-        client_ip = forwarded_for.split(",")[0] or None
+        if settings.USE_X_FORWARDED_FOR:
+            forwarded_for = request.headers.get("x-forwarded-for", "")
+            client_ip = forwarded_for.split(",")[0] or None
 
         if not client_ip:
             client_ip = request.META.get("REMOTE_ADDR")

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -64,9 +64,18 @@ def set_current_service(service):
     _thread_locals.service = service
 
 
+def get_current_request():
+    return getattr(_thread_locals, "request", None)
+
+
 def get_current_user():
-    request = getattr(_thread_locals, "request", None)
+    request = get_current_request()
     return getattr(request, "user", None) if request else None
+
+
+def get_original_client_ip():
+    request = get_current_request()
+    return request.headers.get("x-forwarded-for") if request else None
 
 
 def get_current_service():

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -74,8 +74,14 @@ def get_current_user():
 
 
 def get_original_client_ip():
+    client_ip = None
+
     request = get_current_request()
-    return request.headers.get("x-forwarded-for") if request else None
+    if request:
+        forwarded_for = request.headers.get("x-forwarded-for", "")
+        client_ip = forwarded_for.split(",")[0] or None
+
+    return client_ip
 
 
 def get_current_service():


### PR DESCRIPTION
The HTTP request's "X-Forwarded-For" header is used to get the original client's IP address. If there's no such header, then no IP information goes into the audit log.

Note: this hasn't been tested in any deployment yet, so it's unsure if the used infrastructure really provide this header. A validated guess is that it does.

This PR implements sub-task HP-529. As it's the final sub-task of the parent task, this also completes HP-178.