### PR TITLE
Ignore directories starting with .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ sftp-config.json
 target/
 var/
 venv/
+.venv*/
 .pytest_cache/
 docker-compose.env.yaml
 .vscode/settings.json

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ max-complexity = 10
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = open_city_profile.tests.settings
-norecursedirs = bower_components node_modules .git venv*
+norecursedirs = bower_components node_modules .git venv* .venv*
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE
 
 [coverage:run]
@@ -28,6 +28,7 @@ multi_line_output=3
 not_skip=__init__.py
 order_by_type=false
 skip=migrations,venv,snapshots
+skip_glob=.venv*
 include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True


### PR DESCRIPTION
In .gitignore and for some tools.

This can be used as a common prefix for Python virtual environments.