### PR TITLE
YM-460 | Temporarily remove a migration which prevents rollback after release

### DIFF
--- a/open_city_profile/migrations/0001_remove_allauth_remnants.py
+++ b/open_city_profile/migrations/0001_remove_allauth_remnants.py
@@ -1,27 +1,12 @@
 from django.db import migrations
 
 
-def remove_contenttypes(apps, schema_editor):
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    ContentType.objects.filter(app_label="account").delete()
-    ContentType.objects.filter(app_label="socialaccount").delete()
-
-
 class Migration(migrations.Migration):
     dependencies = []
 
-    tables_to_remove = [
-        "account_emailaddress",
-        "account_emailconfirmation",
-        "socialaccount_socialaccount",
-        "socialaccount_socialapp",
-        "socialaccount_socialapp_sites",
-        "socialaccount_socialtoken",
-    ]
-
+    # Removed the operations for destroying data, to allow for doing a
+    # rollback during the next release.
     operations = [
-        migrations.RunPython(remove_contenttypes),
-        migrations.RunSQL(
-            "DROP TABLE IF EXISTS {}".format(", ".join(tables_to_remove))
-        ),
+        migrations.RunPython(migrations.RunPython.noop, migrations.RunPython.noop),
+        migrations.RunSQL(migrations.RunSQL.noop, migrations.RunSQL.noop),
     ]


### PR DESCRIPTION
Current production version uses the tables which are removed in the related migration. This migrations is not strictly needed for the new production release so, we'll temporarily remove it before the release to allow for a possible rollback using Django migrations.

Refs YM-460

P.S. This migration will be re-added after the release has been deemed successful. 