### PR TITLE
Show any available name in admin UI's Users list

### DIFF
--- a/profiles/migrations/0035_add_raw_verifiedpersonalinformation_names.py
+++ b/profiles/migrations/0035_add_raw_verifiedpersonalinformation_names.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+
+
+def copy_names_to_raw_fields(apps, schema_editor):
+    VerifiedPersonalInformation = apps.get_model(
+        "profiles", "VerifiedPersonalInformation"
+    )
+    for obj in VerifiedPersonalInformation.objects.all():
+        obj.new_first_name = obj.first_name
+        obj.new_last_name = obj.last_name
+        obj.save()
+
+
+def copy_names_from_raw_fields(apps, schema_editor):
+    VerifiedPersonalInformation = apps.get_model(
+        "profiles", "VerifiedPersonalInformation"
+    )
+    for obj in VerifiedPersonalInformation.objects.all():
+        obj.first_name = obj.new_first_name
+        obj.last_name = obj.new_last_name
+        obj.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("profiles", "0034_add_help_texts_to_fields__noop"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="verifiedpersonalinformation",
+            name="new_first_name",
+            field=models.CharField(
+                blank=True, help_text="First name(s).", max_length=1024
+            ),
+        ),
+        migrations.AddField(
+            model_name="verifiedpersonalinformation",
+            name="new_last_name",
+            field=models.CharField(blank=True, help_text="Last name.", max_length=1024),
+        ),
+        migrations.RunPython(
+            copy_names_to_raw_fields, reverse_code=copy_names_from_raw_fields,
+        ),
+    ]

--- a/profiles/migrations/0036_start_using_raw_verifiedpersonalinformation_names.py
+++ b/profiles/migrations/0036_start_using_raw_verifiedpersonalinformation_names.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("profiles", "0035_add_raw_verifiedpersonalinformation_names"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="verifiedpersonalinformation", name="first_name",
+        ),
+        migrations.RenameField(
+            model_name="verifiedpersonalinformation",
+            old_name="new_first_name",
+            new_name="first_name",
+        ),
+        migrations.RemoveField(
+            model_name="verifiedpersonalinformation", name="last_name",
+        ),
+        migrations.RenameField(
+            model_name="verifiedpersonalinformation",
+            old_name="new_last_name",
+            new_name="last_name",
+        ),
+    ]

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -239,12 +239,10 @@ class VerifiedPersonalInformation(ValidateOnSaveModel, NullsToEmptyStringsModel)
     profile = models.OneToOneField(
         Profile, on_delete=models.CASCADE, related_name="verified_personal_information"
     )
-    first_name = fields.EncryptedCharField(
+    first_name = models.CharField(
         max_length=1024, blank=True, help_text="First name(s)."
     )
-    last_name = fields.EncryptedCharField(
-        max_length=1024, blank=True, help_text="Last name."
-    )
+    last_name = models.CharField(max_length=1024, blank=True, help_text="Last name.")
     given_name = fields.EncryptedCharField(
         max_length=1024, blank=True, help_text="The name the person is called with."
     )

--- a/profiles/tests/test_migrations.py
+++ b/profiles/tests/test_migrations.py
@@ -87,3 +87,34 @@ def test_fix_primary_email_migration(migration_test_db):
     execute_migration_test(
         "0024_order_emails", "0025_fix_primary_emails", create_data, verify_migration
     )
+
+
+def test_verified_personal_information_searchable_names_migration(migration_test_db):
+    FIRST_NAME = "First name"
+    LAST_NAME = "Last name"
+
+    def create_data(apps):
+        Profile = apps.get_model(app, "Profile")
+        VerifiedPersonalInformation = apps.get_model(app, "VerifiedPersonalInformation")
+        profile = Profile.objects.create()
+        VerifiedPersonalInformation.objects.create(
+            profile=profile, first_name=FIRST_NAME, last_name=LAST_NAME
+        )
+
+    def verify_migration(apps):
+        VerifiedPersonalInformation = apps.get_model(app, "VerifiedPersonalInformation")
+        vpi = VerifiedPersonalInformation.objects.get(
+            first_name__icontains=FIRST_NAME[:4].lower()
+        )
+        assert vpi.first_name == FIRST_NAME
+        vpi = VerifiedPersonalInformation.objects.get(
+            last_name__icontains=LAST_NAME[:4].lower()
+        )
+        assert vpi.last_name == LAST_NAME
+
+    execute_migration_test(
+        "0034_add_help_texts_to_fields__noop",
+        "0036_start_using_raw_verifiedpersonalinformation_names",
+        create_data,
+        verify_migration,
+    )

--- a/profiles/tests/test_migrations.py
+++ b/profiles/tests/test_migrations.py
@@ -2,64 +2,88 @@ import pytest
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 
+app = "profiles"
 
-def test_fix_primary_email_migration(migration_test_db):
+
+def execute_migration_test(migrate_from, migrate_to, before_migration, after_migration):
+    migrate_from = [(app, migrate_from)]
+    migrate_to = [(app, migrate_to)]
+
     executor = MigrationExecutor(connection)
-    app = "profiles"
-    migrate_from = [(app, "0024_order_emails")]
-    migrate_to = [(app, "0025_fix_primary_emails")]
-
     executor.migrate(migrate_from)
     old_apps = executor.loader.project_state(migrate_from).apps
 
-    # Create some old data.
-    Profile = old_apps.get_model(app, "Profile")
-    Email = old_apps.get_model(app, "Email")
-
-    profile_with_one_primary_email = Profile.objects.create()
-    Email.objects.create(
-        profile=profile_with_one_primary_email,
-        email="profile_with_one_primary_email@example.com",
-        primary=True,
-    )
-
-    profile_with_emails_but_no_primary_email = Profile.objects.create()
-    Email.objects.create(
-        profile=profile_with_emails_but_no_primary_email,
-        email="profile_with_emails_but_no_primary_email@example.com",
-        primary=False,
-    )
-
-    profile_with_no_email = Profile.objects.create()
-
-    profile_with_multiple_primary_emails = Profile.objects.create()
-    Email.objects.create(
-        profile=profile_with_multiple_primary_emails,
-        email="profile_with_multiple_primary_emails_1@example.com",
-        primary=True,
-    )
-    Email.objects.create(
-        profile=profile_with_multiple_primary_emails,
-        email="profile_with_multiple_primary_emails_2@example.com",
-        primary=True,
-    )
+    passable_data = before_migration(old_apps) or ()
 
     # Migrate forwards.
     executor.loader.build_graph()  # reload.
     executor.migrate(migrate_to)
     new_apps = executor.loader.project_state(migrate_to).apps
 
-    # Test the new data.
-    Profile = new_apps.get_model(app, "Profile")
+    after_migration(new_apps, *passable_data)
 
-    profile = Profile.objects.get(pk=profile_with_one_primary_email.pk)
-    assert profile.emails.filter(primary=True).count() == 1
 
-    profile = Profile.objects.get(pk=profile_with_emails_but_no_primary_email.pk)
-    assert profile.emails.filter(primary=True).count() == 1
+def test_fix_primary_email_migration(migration_test_db):
+    def create_data(apps):
+        Profile = apps.get_model(app, "Profile")
+        Email = apps.get_model(app, "Email")
 
-    with pytest.raises(Profile.DoesNotExist):
-        Profile.objects.get(pk=profile_with_no_email.pk)
+        profile_with_one_primary_email = Profile.objects.create()
+        Email.objects.create(
+            profile=profile_with_one_primary_email,
+            email="profile_with_one_primary_email@example.com",
+            primary=True,
+        )
 
-    profile = Profile.objects.get(pk=profile_with_multiple_primary_emails.pk)
-    assert profile.emails.filter(primary=True).count() == 1
+        profile_with_emails_but_no_primary_email = Profile.objects.create()
+        Email.objects.create(
+            profile=profile_with_emails_but_no_primary_email,
+            email="profile_with_emails_but_no_primary_email@example.com",
+            primary=False,
+        )
+
+        profile_with_no_email = Profile.objects.create()
+
+        profile_with_multiple_primary_emails = Profile.objects.create()
+        Email.objects.create(
+            profile=profile_with_multiple_primary_emails,
+            email="profile_with_multiple_primary_emails_1@example.com",
+            primary=True,
+        )
+        Email.objects.create(
+            profile=profile_with_multiple_primary_emails,
+            email="profile_with_multiple_primary_emails_2@example.com",
+            primary=True,
+        )
+
+        return (
+            profile_with_one_primary_email,
+            profile_with_emails_but_no_primary_email,
+            profile_with_no_email,
+            profile_with_multiple_primary_emails,
+        )
+
+    def verify_migration(
+        apps,
+        profile_with_one_primary_email,
+        profile_with_emails_but_no_primary_email,
+        profile_with_no_email,
+        profile_with_multiple_primary_emails,
+    ):
+        Profile = apps.get_model(app, "Profile")
+
+        profile = Profile.objects.get(pk=profile_with_one_primary_email.pk)
+        assert profile.emails.filter(primary=True).count() == 1
+
+        profile = Profile.objects.get(pk=profile_with_emails_but_no_primary_email.pk)
+        assert profile.emails.filter(primary=True).count() == 1
+
+        with pytest.raises(Profile.DoesNotExist):
+            Profile.objects.get(pk=profile_with_no_email.pk)
+
+        profile = Profile.objects.get(pk=profile_with_multiple_primary_emails.pk)
+        assert profile.emails.filter(primary=True).count() == 1
+
+    execute_migration_test(
+        "0024_order_emails", "0025_fix_primary_emails", create_data, verify_migration
+    )

--- a/users/admin.py
+++ b/users/admin.py
@@ -17,11 +17,11 @@ class UserAdmin(VersionAdmin, DjangoUserAdmin):
         "uuid",
         "get_profile_uuid_link",
         "email",
-        "first_name",
-        "last_name",
+        "get_first_name",
+        "get_last_name",
         "is_staff",
     )
-    list_select_related = ("profile",)
+    list_select_related = ("profile", "profile__verified_personal_information")
     search_fields = ("uuid", "first_name", "last_name", "email", "profile__id")
 
     def get_fieldsets(self, request, obj=None):
@@ -46,3 +46,21 @@ class UserAdmin(VersionAdmin, DjangoUserAdmin):
 
     get_profile_uuid_link.short_description = _("Profile")
     get_profile_uuid_link.admin_order_field = "profile__id"
+
+    def get_first_name(self, obj):
+        return (
+            obj.first_name
+            or obj.profile.first_name
+            or obj.profile.verified_personal_information.first_name
+        )
+
+    get_first_name.short_description = _("First name")
+
+    def get_last_name(self, obj):
+        return (
+            obj.last_name
+            or obj.profile.last_name
+            or obj.profile.verified_personal_information.last_name
+        )
+
+    get_last_name.short_description = _("Last name")

--- a/users/admin.py
+++ b/users/admin.py
@@ -15,12 +15,14 @@ User = get_user_model()
 class UserAdmin(VersionAdmin, DjangoUserAdmin):
     list_display = (
         "uuid",
+        "get_profile_uuid_link",
         "email",
         "first_name",
         "last_name",
         "is_staff",
     )
-    search_fields = ("uuid", "first_name", "last_name", "email")
+    list_select_related = ("profile",)
+    search_fields = ("uuid", "first_name", "last_name", "email", "profile__id")
 
     def get_fieldsets(self, request, obj=None):
         fieldsets = super().get_fieldsets(request, obj)
@@ -43,3 +45,4 @@ class UserAdmin(VersionAdmin, DjangoUserAdmin):
         )
 
     get_profile_uuid_link.short_description = _("Profile")
+    get_profile_uuid_link.admin_order_field = "profile__id"

--- a/users/admin.py
+++ b/users/admin.py
@@ -22,7 +22,17 @@ class UserAdmin(VersionAdmin, DjangoUserAdmin):
         "is_staff",
     )
     list_select_related = ("profile", "profile__verified_personal_information")
-    search_fields = ("uuid", "first_name", "last_name", "email", "profile__id")
+    search_fields = (
+        "uuid",
+        "first_name",
+        "last_name",
+        "email",
+        "profile__id",
+        "profile__first_name",
+        "profile__last_name",
+        "profile__verified_personal_information__first_name",
+        "profile__verified_personal_information__last_name",
+    )
 
     def get_fieldsets(self, request, obj=None):
         fieldsets = super().get_fieldsets(request, obj)


### PR DESCRIPTION
Commit b5472f7 adds one more feature from HP-521 that wasn't feasible to implement before #271 got in.

Rest of the commits try to show any name for a `User` in the Users list, be it from the User's `Profile`, or from `VerifiedPersonalInformation` as a last resort.

Searching by these names is also possible. The first and last name fields of `VerifiedPersonalInformation` were changed to regular (unencrypted) fields to enable searching.