### PR TITLE
YM-432 | Remove YouthProfile generation from seed_data command

### DIFF
--- a/utils/management/commands/seed_data.py
+++ b/utils/management/commands/seed_data.py
@@ -13,7 +13,6 @@ from utils.utils import (
     generate_profiles,
     generate_service_connections,
     generate_services,
-    generate_youth_profiles,
 )
 
 available_permissions = [item[0] for item in Service._meta.permissions]
@@ -48,13 +47,6 @@ class Command(BaseCommand):
             default=50,
         )
         parser.add_argument(
-            "-y",
-            "--youthprofilepercentage",
-            type=float,
-            help="Percentage of profiles to have youth profile",
-            default=0.2,
-        )
-        parser.add_argument(
             "-l",
             "--locale",
             type=str,
@@ -79,7 +71,6 @@ class Command(BaseCommand):
         locale = kwargs["locale"]
         faker = Faker(locale)
         profile_count = kwargs["profilecount"]
-        youth_profile_percentage = kwargs["youthprofilepercentage"]
 
         if not no_clear and (development or clear):
             self.stdout.write("Clearing data...")
@@ -125,8 +116,6 @@ class Command(BaseCommand):
                 self.stdout.write(f"Generating profiles ({profile_count})...")
                 generate_profiles(profile_count, faker=faker)
                 self.stdout.write("Generating service connections...")
-                generate_service_connections(youth_profile_percentage)
-                self.stdout.write("Generating youth profiles...")
-                generate_youth_profiles(faker=faker)
+                generate_service_connections()
 
             self.stdout.write(self.style.SUCCESS("Done - Development fake data"))

--- a/utils/tests/test_commands.py
+++ b/utils/tests/test_commands.py
@@ -7,7 +7,6 @@ from services.models import AllowedDataField, Service
 from subscriptions.models import SubscriptionType, SubscriptionTypeCategory
 from users.models import User
 from utils.utils import DATA_FIELD_VALUES
-from youths.models import YouthProfile
 
 
 def test_command_seed_data_works_without_arguments():
@@ -37,7 +36,6 @@ def test_command_seed_data_initializes_development_data():
         == normal_users + len(ServiceType) + admin_users + anonymous_users
     )
     assert Profile.objects.count() == normal_users
-    assert YouthProfile.objects.count() == 10
     assert User.objects.filter(is_superuser=True).count() == admin_users
 
 
@@ -46,11 +44,9 @@ def test_command_seed_data_works_withs_arguments():
         "--development",
         "--no-clear",  # Flushing not needed in tests + it caused test failures
         "--profilecount=20",
-        "--youthprofilepercentage=0.5",
         "--locale=fi_FI",
         "--superuser",
     ]
     call_command("seed_data", *args)
     assert Profile.objects.count() == 20
-    assert YouthProfile.objects.count() == 10
     assert User.objects.filter(is_superuser=True).count() == 1

--- a/utils/tests/test_utils.py
+++ b/utils/tests/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.auth.models import Group
+from django.db.models import Count
 from faker import Faker
 from guardian.shortcuts import get_group_perms
 
@@ -18,9 +19,7 @@ from utils.utils import (
     generate_profiles,
     generate_service_connections,
     generate_services,
-    generate_youth_profiles,
 )
-from youths.models import YouthProfile
 
 
 @pytest.mark.parametrize("times", [1, 2])
@@ -105,39 +104,21 @@ def test_generates_default_amount_of_profiles():
     assert Profile.objects.count() == 50
 
 
-@pytest.mark.parametrize(
-    "profiles,youth_percentage", [(5, 0.2), (10, 0.5), (10, 0), (0, 1)]
-)
-def test_generate_service_connections(profiles, youth_percentage):
+@pytest.mark.parametrize("profiles", [5, 10, 0])
+def test_generate_service_connections(profiles):
     """Service connection is generated for all profiles,"""
     generate_services()
     generate_profiles(k=profiles, faker=Faker())
 
-    generate_service_connections(youth_percentage)
+    generate_service_connections()
 
     assert ServiceConnection.objects.count() == profiles
-    assert ServiceConnection.objects.filter(
-        service__service_type=ServiceType.YOUTH_MEMBERSHIP
-    ).count() == int(profiles * youth_percentage)
-    assert YouthProfile.objects.count() == 0
-
-
-@pytest.mark.parametrize(
-    "profiles,youth_percentage", [(5, 0.2), (10, 0.5), (10, 0), (0, 1)]
-)
-def test_generates_youth_profiles(profiles, youth_percentage):
-    """Youth profiles are generated for all profiles which have youth membership ServiceConnection."""
-    generate_services()
-    generate_profiles(k=profiles, faker=Faker())
-    generate_service_connections(youth_percentage)
-
-    generate_youth_profiles(faker=Faker())
-
-    assert YouthProfile.objects.count() == int(profiles * youth_percentage)
-    # Assert that youth membership service connections have youth membership profile
-    assert Profile.objects.filter(
-        service_connections__service__service_type=ServiceType.YOUTH_MEMBERSHIP
-    ).count() == int(profiles * youth_percentage)
+    assert (
+        Profile.objects.annotate(Count("service_connections"))
+        .filter(service_connections__count=1)
+        .count()
+        == profiles
+    )
 
 
 @pytest.mark.parametrize("times", [1, 2])

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -12,8 +12,6 @@ from profiles.models import Address, Email, Phone, Profile
 from services.enums import ServiceType
 from services.models import AllowedDataField, Service, ServiceConnection
 from users.models import User
-from youths.enums import YouthLanguage
-from youths.models import YouthProfile
 
 DATA_FIELD_VALUES = [
     {
@@ -250,51 +248,12 @@ def generate_profiles(k=50, faker=None):
         )
 
 
-def generate_service_connections(youth_profile_percentage=0.2):
+def generate_service_connections():
     """Create fake service connections for development purposes."""
     profiles = Profile.objects.all()
-    number_of_youth_profiles_to_generate = int(
-        profiles.count() * youth_profile_percentage
-    )
-
-    youth_service = Service.objects.get(service_type=ServiceType.YOUTH_MEMBERSHIP)
-    other_services = Service.objects.exclude(pk=youth_service.pk)
-
-    for index, profile in enumerate(profiles):
-        if index < number_of_youth_profiles_to_generate:
-            ServiceConnection.objects.create(profile=profile, service=youth_service)
-        else:
-            ServiceConnection.objects.create(
-                profile=profile, service=random.choice(other_services)
-            )
-
-
-def generate_youth_profiles(faker=None):
-    """Create fake youth membership profiles for development purposes."""
-    profiles = Profile.objects.filter(
-        service_connections__service__service_type=ServiceType.YOUTH_MEMBERSHIP
-    )
+    services = Service.objects.all()
 
     for profile in profiles:
-        approved = bool(random.getrandbits(1))
-        YouthProfile.objects.create(
-            profile=profile,
-            birth_date=make_aware(
-                faker.date_time_between(start_date="-17y", end_date="-13y"),
-                get_current_timezone(),
-                is_dst=False,
-            ),
-            language_at_home=random.choice(list(YouthLanguage)),
-            approver_first_name=faker.first_name() if approved else "",
-            approver_last_name=profile.last_name if approved else "",
-            approved_time=make_aware(
-                faker.date_time_between(
-                    start_date=profile.user.date_joined, end_date="now"
-                ),
-                get_current_timezone(),
-                is_dst=False,
-            )
-            if approved
-            else None,
-            photo_usage_approved=bool(random.getrandbits(1)) if approved else False,
+        ServiceConnection.objects.create(
+            profile=profile, service=random.choice(services)
         )


### PR DESCRIPTION
This PR removes `YouthProfile` related logic from the part of `seed_data` command which generates development data.