### PR TITLE
Remove odd ServiceServiceType type from GraphQL schema

### DIFF
--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -401,7 +401,6 @@ input ServiceInput {
 
 type ServiceNode implements Node {
   id: ID!
-  serviceType: ServiceServiceType!
   allowedDataFields(before: String, after: String, first: Int, last: Int): AllowedDataFieldNodeConnection!
   createdAt: DateTime!
   gdprUrl: String!
@@ -421,13 +420,6 @@ type ServiceNodeConnection {
 type ServiceNodeEdge {
   node: ServiceNode
   cursor: String!
-}
-
-enum ServiceServiceType {
-  HELSINKI_MY_DATA
-  BERTH
-  YOUTH_MEMBERSHIP
-  GODCHILDREN_OF_CULTURE
 }
 
 enum ServiceType {

--- a/services/schema.py
+++ b/services/schema.py
@@ -30,6 +30,15 @@ class ServiceNode(DjangoObjectType):
 
     class Meta:
         model = Service
+        fields = (
+            "id",
+            "allowed_data_fields",
+            "created_at",
+            "gdpr_url",
+            "gdpr_query_scope",
+            "gdpr_delete_scope",
+            "serviceconnection_set",
+        )
         filter_fields = []
         interfaces = (relay.Node,)
 


### PR DESCRIPTION
It looks like nobody ever intended this type (and the `serviceType` field in `ServiceNode`) to be present. `ServiceNode` also contains a `type` field of type `ServiceType` which serves the exactly same purpose.