### PR TITLE
Revert buffered audit logging

### DIFF
--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -194,7 +194,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "reversion.middleware.RevisionMiddleware",
-    "profiles.middleware.ProfilesMiddleware",
+    "profiles.middleware.SetCurrentRequest",
 ]
 
 TEMPLATES = [

--- a/profiles/audit_log.py
+++ b/profiles/audit_log.py
@@ -1,32 +1,16 @@
 import json
 import logging
-import threading
 from datetime import datetime, timezone
 
 from django.conf import settings
 
 from .utils import get_current_service, get_current_user, get_original_client_ip
 
-_thread_locals = threading.local()
 
-
-def _should_audit(model):
+def should_audit(model):
     if hasattr(model, "audit_log") and model.audit_log:
         return True
     return False
-
-
-def add_loggable(action, instance):
-    if (
-        settings.AUDIT_LOGGING_ENABLED
-        and _should_audit(instance.__class__)
-        and instance.pk
-    ):
-        current_time = datetime.now(tz=timezone.utc)
-
-        if not hasattr(_thread_locals, "loggables"):
-            _thread_locals.loggables = list()
-        _thread_locals.loggables.append((current_time, action, instance))
 
 
 def _resolve_role(current_user, profile):
@@ -49,15 +33,20 @@ def _format_user_data(audit_event, field_name, user):
             )
 
 
-def flush_audit_log():
+def log(action, instance):
     profile_parts = {
         "Profile": "base profile",
         "SensitiveData": "sensitive data",
     }
 
-    logger = logging.getLogger("audit")
+    if (
+        settings.AUDIT_LOGGING_ENABLED
+        and should_audit(instance.__class__)
+        and instance.pk
+    ):
+        logger = logging.getLogger("audit")
 
-    for event_time, action, instance in getattr(_thread_locals, "loggables", list()):
+        current_time = datetime.now(tz=timezone.utc)
         current_user = get_current_user()
         profile = instance.resolve_profile()
         profile_id = str(profile.pk) if profile else None
@@ -67,8 +56,8 @@ def flush_audit_log():
             "audit_event": {
                 "origin": "PROFILE-BE",
                 "status": "SUCCESS",
-                "date_time_epoch": int(event_time.timestamp()),
-                "date_time": f"{event_time.replace(tzinfo=None).isoformat(sep='T', timespec='milliseconds')}Z",
+                "date_time_epoch": int(current_time.timestamp()),
+                "date_time": f"{current_time.replace(tzinfo=None).isoformat(sep='T', timespec='milliseconds')}Z",
                 "actor": {"role": _resolve_role(current_user, profile)},
                 "operation": action,
                 "target": {
@@ -96,5 +85,3 @@ def flush_audit_log():
             }
 
         logger.info(json.dumps(message))
-
-    _thread_locals.loggables = list()

--- a/profiles/log_signals.py
+++ b/profiles/log_signals.py
@@ -1,22 +1,22 @@
 from django.db.models.signals import post_delete, post_init, post_save
 from django.dispatch import receiver
 
-from .audit_log import add_loggable
+from .audit_log import log
 
 
 @receiver(post_delete)
 def post_delete_audit_log(sender, instance, **kwargs):
-    add_loggable("DELETE", instance)
+    log("DELETE", instance)
 
 
 @receiver(post_init)
 def post_init_audit_log(sender, instance, **kwargs):
-    add_loggable("READ", instance)
+    log("READ", instance)
 
 
 @receiver(post_save)
 def post_save_audit_log(sender, instance, created, **kwargs):
     if created:
-        add_loggable("CREATE", instance)
+        log("CREATE", instance)
     else:
-        add_loggable("UPDATE", instance)
+        log("UPDATE", instance)

--- a/profiles/middleware.py
+++ b/profiles/middleware.py
@@ -1,6 +1,5 @@
 from django.utils.deprecation import MiddlewareMixin
 
-from .audit_log import flush_audit_log
 from .utils import clear_thread_locals, set_current_request
 
 
@@ -9,6 +8,5 @@ class SetCurrentRequest(MiddlewareMixin):
         set_current_request(request)
 
     def process_response(self, request, response):
-        flush_audit_log()
         clear_thread_locals()
         return response

--- a/profiles/middleware.py
+++ b/profiles/middleware.py
@@ -4,7 +4,7 @@ from .audit_log import flush_audit_log
 from .utils import clear_thread_locals, set_current_request
 
 
-class ProfilesMiddleware(MiddlewareMixin):
+class SetCurrentRequest(MiddlewareMixin):
     def process_request(self, request):
         set_current_request(request)
 

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from open_city_profile.tests.asserts import assert_almost_equal
 from open_city_profile.tests.conftest import get_unix_timestamp_now
 from open_city_profile.tests.graphql_test_helpers import do_graphql_call_as_user
-from profiles.audit_log import flush_audit_log
 from profiles.models import Profile
 
 from .factories import ProfileFactory
@@ -26,12 +25,7 @@ def enable_audit_log_username():
 
 @pytest.fixture
 def cap_audit_log(caplog):
-    flush_audit_log()
-    caplog.clear()
-
     def get_logs(self):
-        flush_audit_log()
-
         audit_records = [
             r for r in self.records if r.name == "audit" and r.levelno == logging.INFO
         ]
@@ -55,16 +49,19 @@ def assert_common_fields(log_message, actor_role="SYSTEM"):
     assert_almost_equal(log_dt, now_dt, timedelta(seconds=1))
 
 
-def test_audit_log_read(user, enable_audit_log, profile, cap_audit_log):
-    profile_from_db = Profile.objects.first()
+def test_audit_log_read(user, enable_audit_log, cap_audit_log):
+    ProfileFactory()
+
+    cap_audit_log.clear()
+    profile = Profile.objects.first()
     audit_logs = cap_audit_log.get_logs()
     assert len(audit_logs) == 1
     log_message = audit_logs[0]
     assert_common_fields(log_message)
     assert log_message["audit_event"]["operation"] == "READ"
     assert log_message["audit_event"]["target"] == {
-        "user_id": str(profile_from_db.user.uuid),
-        "profile_id": str(profile_from_db.pk),
+        "user_id": str(profile.user.uuid),
+        "profile_id": str(profile.pk),
         "profile_part": "base profile",
     }
 


### PR DESCRIPTION
Reverts #271 (except commit 5f3155f7f5, which just organized code and is useful by itself).

The buffered audit logging introduced more serious problems than it fixed. The previous version caused some performance issues. The buffered version might cause audit logging to fail, when models are deleted, as they might not be present in the database anymore at the time of logging.