### PR TITLE
Enable deleting the related User when deleting a Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ This repository contains `requirements*.in` and corresponding `requirements*.txt
 5. To install Python requirements run:
     * `pip-sync requirements.txt`
 
+**Note:** when updating dependencies, read the [dependency update checklist](docs/dependency-update.adoc) if there's anything you need to pay attention to.
+
 ## Code format
 
 This project uses

--- a/docs/dependency-update.adoc
+++ b/docs/dependency-update.adoc
@@ -1,0 +1,5 @@
+= Checklist for updating dependencies
+
+== Django
+
+- `templates/admin/profiles/profile/delete_confirmation.html` has parts copied from Django (`django/contrib/admin/templates/admin/delete_confirmation.html`) and customised. Customisations are surrounded by comments. When updating Django, check if the original template has changed and update the customised template accordingly.

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -209,3 +209,9 @@ class ExtendedProfileAdmin(VersionAdmin):
             )
         formfield = super().formfield_for_manytomany(db_field, request, **kwargs)
         return formfield
+
+    def delete_model(self, request, obj):
+        user = obj.user
+        super().delete_model(request, obj)
+        if user and request.POST.get("delete-user"):
+            user.delete()

--- a/templates/admin/profiles/profile/delete_confirmation.html
+++ b/templates/admin/profiles/profile/delete_confirmation.html
@@ -1,0 +1,42 @@
+{% extends 'admin/delete_confirmation.html' %}
+{% load i18n %}
+
+{% block content %}
+{% if perms_lacking %}
+    <p>{% blocktrans with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktrans %}</p>
+    <ul>
+    {% for obj in perms_lacking %}
+        <li>{{ obj }}</li>
+    {% endfor %}
+    </ul>
+{% elif protected %}
+    <p>{% blocktrans with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would require deleting the following protected related objects:{% endblocktrans %}</p>
+    <ul>
+    {% for obj in protected %}
+        <li>{{ obj }}</li>
+    {% endfor %}
+    </ul>
+{% else %}
+    <p>{% blocktrans with escaped_object=object %}Are you sure you want to delete the {{ object_name }} "{{ escaped_object }}"? All of the following related items will be deleted:{% endblocktrans %}</p>
+    {% include "admin/includes/object_delete_summary.html" %}
+    <h2>{% trans "Objects" %}</h2>
+    <ul>{{ deleted_objects|unordered_list }}</ul>
+    <form method="post">{% csrf_token %}
+    {# Customisation starts ---> #}
+    <div>
+        <label>
+            <input type="checkbox" name="delete-user">
+            {% trans "Also delete the related User?" %}
+        </label>
+    </div>
+    {# <--- customisation ends #}
+    <div>
+    <input type="hidden" name="post" value="yes">
+    {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
+    {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
+    <input type="submit" value="{% trans "Yes, I'm sure" %}">
+    <a href="#" class="button cancel-link">{% trans "No, take me back" %}</a>
+    </div>
+    </form>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
The Profile deletion confirmation screen contains a checkbox that can be used to control if the related User should get deleted as well.

Extending the confirmation screen is a bit cumbersome. In this commit the content block part of the original template is copied and a few lines of custom HTML is inserted into it. The inserted part is indicated with comments in the template.