### PR TITLE
OM-933 | Stop logging requests for /healthz and /readiness endoints

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -9,3 +9,6 @@ buffer-size = 32768
 master = 1
 processes = 2
 threads = 2
+; don't log readiness and healthz endpoints
+route = ^/readiness$ donotlog:
+route = ^/healthz$ donotlog:


### PR DESCRIPTION
This PR stops uWSGI from logging requests for /healthz and /readiness endoints.