### PR TITLE
Simplify graphql testing

### DIFF
--- a/open_city_profile/tests/conftest.py
+++ b/open_city_profile/tests/conftest.py
@@ -72,33 +72,27 @@ def group():
     return GroupFactory()
 
 
-def get_gql_client_with_error_formating():
+def _get_gql_client_with_error_formating():
     return GraphQLClient(schema, format_error=GraphQLView.format_error)
 
 
 @pytest.fixture
-def gql_client():
-    gql_client = get_gql_client_with_error_formating()
-    return gql_client
-
-
-@pytest.fixture
 def anon_user_gql_client(anon_user):
-    gql_client = get_gql_client_with_error_formating()
+    gql_client = _get_gql_client_with_error_formating()
     gql_client.user = anon_user
     return gql_client
 
 
 @pytest.fixture
 def user_gql_client(user):
-    gql_client = get_gql_client_with_error_formating()
+    gql_client = _get_gql_client_with_error_formating()
     gql_client.user = user
     return gql_client
 
 
 @pytest.fixture
 def superuser_gql_client(superuser):
-    gql_client = get_gql_client_with_error_formating()
+    gql_client = _get_gql_client_with_error_formating()
     gql_client.user = superuser
     return gql_client
 

--- a/open_city_profile/tests/conftest.py
+++ b/open_city_profile/tests/conftest.py
@@ -19,7 +19,7 @@ from open_city_profile.views import GraphQLView
 
 
 class GraphQLClient(GrapheneClient):
-    def execute(self, *args, context=None, **kwargs):
+    def execute(self, *args, service=None, context=None, **kwargs):
         """
         Custom wrapper on the execute method, allows adding the
         GQL DataLoaders middleware, since it has to be added to make
@@ -30,6 +30,9 @@ class GraphQLClient(GrapheneClient):
 
         if not hasattr(context, "user") and hasattr(self, "user"):
             context.user = self.user
+
+        if service is not None:
+            context.service = service
 
         return super().execute(
             *args, context=context, middleware=[GQLDataLoaders()], **kwargs

--- a/profiles/tests/test_gql_claimable_profile_query.py
+++ b/profiles/tests/test_gql_claimable_profile_query.py
@@ -9,11 +9,9 @@ from open_city_profile.consts import TOKEN_EXPIRED_ERROR
 from .factories import ClaimTokenFactory, ProfileFactory
 
 
-def test_can_query_claimable_profile_with_token(rf, user_gql_client):
+def test_can_query_claimable_profile_with_token(user_gql_client):
     profile = ProfileFactory(user=None, first_name="John", last_name="Doe")
     claim_token = ClaimTokenFactory(profile=profile)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -34,18 +32,16 @@ def test_can_query_claimable_profile_with_token(rf, user_gql_client):
             "lastName": profile.last_name,
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
 
     assert "errors" not in executed
     assert dict(executed["data"]) == expected_data
 
 
 def test_cannot_query_claimable_profile_with_user_already_attached(
-    rf, user_gql_client, profile
+    user_gql_client, profile
 ):
     claim_token = ClaimTokenFactory(profile=profile)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -57,18 +53,16 @@ def test_cannot_query_claimable_profile_with_user_already_attached(
         """
     )
     query = t.substitute(claimToken=claim_token.token)
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
 
     assert "errors" in executed
 
 
-def test_cannot_query_claimable_profile_with_expired_token(rf, user_gql_client):
+def test_cannot_query_claimable_profile_with_expired_token(user_gql_client):
     profile = ProfileFactory(user=None)
     claim_token = ClaimTokenFactory(
         profile=profile, expires_at=timezone.now() - timedelta(days=1)
     )
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -80,7 +74,7 @@ def test_cannot_query_claimable_profile_with_expired_token(rf, user_gql_client):
         """
     )
     query = t.substitute(claimToken=claim_token.token)
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
 
     assert "errors" in executed
     assert executed["errors"][0]["extensions"]["code"] == TOKEN_EXPIRED_ERROR

--- a/profiles/tests/test_gql_create_my_profile_mutation.py
+++ b/profiles/tests/test_gql_create_my_profile_mutation.py
@@ -5,11 +5,8 @@ import pytest
 
 @pytest.mark.parametrize("email_is_primary", [True, False])
 def test_normal_user_can_create_profile(
-    rf, user_gql_client, email_data, profile_data, email_is_primary
+    user_gql_client, email_data, profile_data, email_is_primary
 ):
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
-
     t = Template(
         """
             mutation {
@@ -67,14 +64,11 @@ def test_normal_user_can_create_profile(
         email_type=email_data["email_type"],
         primary=str(email_is_primary).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert executed["data"] == expected_data
 
 
-def test_normal_user_can_create_profile_with_no_email(rf, user_gql_client, email_data):
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
-
+def test_normal_user_can_create_profile_with_no_email(user_gql_client, email_data):
     mutation = """
             mutation {
                 createMyProfile(
@@ -100,5 +94,5 @@ def test_normal_user_can_create_profile_with_no_email(rf, user_gql_client, email
 
     expected_data = {"createMyProfile": {"profile": {"emails": {"edges": []}}}}
 
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert executed["data"] == expected_data

--- a/profiles/tests/test_gql_create_my_profile_temporary_read_access_token_mutation.py
+++ b/profiles/tests/test_gql_create_my_profile_temporary_read_access_token_mutation.py
@@ -26,13 +26,11 @@ class TestTemporaryProfileReadAccessTokenCreation(
     """
 
     def test_normal_user_can_create_temporary_read_access_token_for_profile(
-        self, rf, user_gql_client
+        self, user_gql_client
     ):
         ProfileFactory(user=user_gql_client.user)
-        request = rf.post("/graphql")
-        request.user = user_gql_client.user
 
-        executed = user_gql_client.execute(self.query, context=request)
+        executed = user_gql_client.execute(self.query)
 
         token_data = executed["data"]["createMyProfileTemporaryReadAccessToken"][
             "temporaryReadAccessToken"
@@ -48,28 +46,23 @@ class TestTemporaryProfileReadAccessTokenCreation(
         )
 
     def test_anonymous_user_cannot_create_any_temporary_read_access_token_for_profile(
-        self, rf, anon_user_gql_client
+        self, anon_user_gql_client
     ):
-        request = rf.post("/graphql")
-        request.user = anon_user_gql_client.user
-
-        executed = anon_user_gql_client.execute(self.query, context=request)
+        executed = anon_user_gql_client.execute(self.query)
 
         assert executed["errors"][0]["extensions"]["code"] == PERMISSION_DENIED_ERROR
 
     def test_other_valid_tokens_are_deleted_when_a_new_token_is_created(
-        self, rf, user_gql_client
+        self, user_gql_client
     ):
         profile = ProfileFactory(user=user_gql_client.user)
-        request = rf.post("/graphql")
-        request.user = user_gql_client.user
 
         valid_token1 = TemporaryReadAccessTokenFactory(profile=profile)
         valid_token2 = TemporaryReadAccessTokenFactory(profile=profile)
         valid_token_for_another_profile = TemporaryReadAccessTokenFactory()
         expired_token = self.create_expired_token(profile)
 
-        executed = user_gql_client.execute(self.query, context=request)
+        executed = user_gql_client.execute(self.query)
         token_data = executed["data"]["createMyProfileTemporaryReadAccessToken"][
             "temporaryReadAccessToken"
         ]

--- a/profiles/tests/test_gql_my_profile_query.py
+++ b/profiles/tests/test_gql_my_profile_query.py
@@ -21,11 +21,10 @@ from .factories import (
 )
 
 
-def test_normal_user_can_query_emails(rf, user_gql_client):
+def test_normal_user_can_query_emails(user_gql_client):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     email = profile.emails.first()
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
+
     query = """
         {
             myProfile {
@@ -56,15 +55,14 @@ def test_normal_user_can_query_emails(rf, user_gql_client):
             }
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_query_phones(rf, user_gql_client):
+def test_normal_user_can_query_phones(user_gql_client):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     phone = PhoneFactory(profile=profile)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
+
     query = """
         {
             myProfile {
@@ -95,15 +93,14 @@ def test_normal_user_can_query_phones(rf, user_gql_client):
             }
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_query_addresses(rf, user_gql_client):
+def test_normal_user_can_query_addresses(user_gql_client):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     address = AddressFactory(profile=profile)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
+
     query = """
         {
             myProfile {
@@ -134,11 +131,11 @@ def test_normal_user_can_query_addresses(rf, user_gql_client):
             }
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_query_primary_contact_details(rf, user_gql_client):
+def test_normal_user_can_query_primary_contact_details(user_gql_client):
     profile = ProfileFactory(user=user_gql_client.user)
     phone = PhoneFactory(profile=profile, primary=True)
     email = EmailFactory(profile=profile, primary=True)
@@ -146,8 +143,7 @@ def test_normal_user_can_query_primary_contact_details(rf, user_gql_client):
     PhoneFactory(profile=profile, primary=False)
     EmailFactory(profile=profile, primary=False)
     AddressFactory(profile=profile, primary=False)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
+
     query = """
         {
             myProfile {
@@ -188,7 +184,7 @@ def test_normal_user_can_query_primary_contact_details(rf, user_gql_client):
             },
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert dict(executed["data"]) == expected_data
 
 
@@ -348,10 +344,9 @@ class TestProfileWithVerifiedPersonalInformation(
         assert executed["data"]["myProfile"]["verifiedPersonalInformation"] is None
 
 
-def test_normal_user_can_query_his_own_profile(rf, user_gql_client):
+def test_normal_user_can_query_his_own_profile(user_gql_client):
     profile = ProfileFactory(user=user_gql_client.user)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
+
     query = """
         {
             myProfile {
@@ -363,15 +358,14 @@ def test_normal_user_can_query_his_own_profile(rf, user_gql_client):
     expected_data = {
         "myProfile": {"firstName": profile.first_name, "lastName": profile.last_name}
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_query_his_own_profiles_sensitivedata(rf, user_gql_client):
+def test_normal_user_can_query_his_own_profiles_sensitivedata(user_gql_client):
     profile = ProfileFactory(user=user_gql_client.user)
     sensitive_data = SensitiveDataFactory(profile=profile)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
+
     query = """
         {
             myProfile {
@@ -388,11 +382,11 @@ def test_normal_user_can_query_his_own_profiles_sensitivedata(rf, user_gql_clien
             "sensitivedata": {"ssn": sensitive_data.ssn},
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_query_his_own_profile_with_subscriptions(rf, user_gql_client):
+def test_normal_user_can_query_his_own_profile_with_subscriptions(user_gql_client):
     profile = ProfileFactory(user=user_gql_client.user)
     cat = SubscriptionTypeCategoryFactory(
         code="TEST-CATEGORY-1", label="Test Category 1"
@@ -407,8 +401,7 @@ def test_normal_user_can_query_his_own_profile_with_subscriptions(rf, user_gql_c
     Subscription.objects.create(
         profile=profile, subscription_type=type_2, enabled=False
     )
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
+
     query = """
         {
             myProfile {
@@ -471,5 +464,5 @@ def test_normal_user_can_query_his_own_profile_with_subscriptions(rf, user_gql_c
             },
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert dict(executed["data"]) == expected_data

--- a/profiles/tests/test_gql_profile_with_access_token_query.py
+++ b/profiles/tests/test_gql_profile_with_access_token_query.py
@@ -21,9 +21,9 @@ class TestTemporaryProfileReadAccessToken(TemporaryProfileReadAccessTokenTestBas
         ).substitute(token=token)
 
     def test_anonymous_user_can_retrieve_a_profile_with_temporary_read_access_token(
-        self, rf, user_gql_client, anon_user_gql_client
+        self, rf, anon_user_gql_client
     ):
-        profile = ProfileFactory(user=user_gql_client.user)
+        profile = ProfileFactory()
         token = TemporaryReadAccessTokenFactory(profile=profile)
 
         request = rf.post("/graphql")
@@ -66,7 +66,7 @@ class TestTemporaryProfileReadAccessToken(TemporaryProfileReadAccessTokenTestBas
         )
 
     def test_using_non_existing_token_reports_profile_not_found_error(
-        self, rf, user_gql_client, anon_user_gql_client
+        self, rf, anon_user_gql_client
     ):
         request = rf.post("/graphql")
         request.user = anon_user_gql_client.user
@@ -80,9 +80,9 @@ class TestTemporaryProfileReadAccessToken(TemporaryProfileReadAccessTokenTestBas
         )
 
     def test_using_an_expired_token_reports_token_expired_error(
-        self, rf, user_gql_client, anon_user_gql_client
+        self, rf, anon_user_gql_client
     ):
-        profile = ProfileFactory(user=user_gql_client.user)
+        profile = ProfileFactory()
         token = self.create_expired_token(profile)
 
         request = rf.post("/graphql")

--- a/profiles/tests/test_gql_profiles_query.py
+++ b/profiles/tests/test_gql_profiles_query.py
@@ -818,12 +818,8 @@ def test_staff_user_with_group_access_can_query_only_profiles_he_has_access_to(
 
 
 def test_not_specifying_requesters_service_results_in_permission_denied_error(
-    rf, user_gql_client
+    user_gql_client,
 ):
-    user = user_gql_client.user
-    request = rf.post("/graphql")
-    request.user = user
-
     query = """
         {
             profiles {
@@ -835,7 +831,7 @@ def test_not_specifying_requesters_service_results_in_permission_denied_error(
             }
         }
     """
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert_match_error_code(executed, "PERMISSION_DENIED_ERROR")
 
 

--- a/profiles/tests/test_gql_schema.py
+++ b/profiles/tests/test_gql_schema.py
@@ -1,6 +1,4 @@
-def test_profile_node_exposes_key_for_federation_gateway(rf, anon_user_gql_client):
-    request = rf.post("/graphql")
-
+def test_profile_node_exposes_key_for_federation_gateway(anon_user_gql_client):
     query = """
         query {
             _service {
@@ -9,16 +7,14 @@ def test_profile_node_exposes_key_for_federation_gateway(rf, anon_user_gql_clien
         }
     """
 
-    executed = anon_user_gql_client.execute(query, context=request)
+    executed = anon_user_gql_client.execute(query)
     assert (
         'type ProfileNode implements Node  @key(fields: "id")'
         in executed["data"]["_service"]["sdl"]
     )
 
 
-def test_profile_connection_schema_matches_federated_schema(rf, anon_user_gql_client):
-    request = rf.post("/graphql")
-
+def test_profile_connection_schema_matches_federated_schema(anon_user_gql_client):
     query = """
         query {
             _service {
@@ -27,7 +23,7 @@ def test_profile_connection_schema_matches_federated_schema(rf, anon_user_gql_cl
         }
     """
 
-    executed = anon_user_gql_client.execute(query, context=request)
+    executed = anon_user_gql_client.execute(query)
     assert (
         "type ProfileNodeConnection {   pageInfo: PageInfo!   "
         "edges: [ProfileNodeEdge]!   count: Int!   totalCount: Int! }"

--- a/profiles/tests/test_gql_update_my_profile_mutation.py
+++ b/profiles/tests/test_gql_update_my_profile_mutation.py
@@ -18,11 +18,9 @@ from .factories import (
 )
 
 
-def test_normal_user_can_update_profile(rf, user_gql_client, email_data, profile_data):
+def test_normal_user_can_update_profile(user_gql_client, email_data, profile_data):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     email = profile.emails.first()
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -89,17 +87,12 @@ def test_normal_user_can_update_profile(rf, user_gql_client, email_data, profile
         email_type=email_data["email_type"],
         primary=str(email_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_update_profile_without_email(
-    rf, user_gql_client, profile_data
-):
+def test_normal_user_can_update_profile_without_email(user_gql_client, profile_data):
     ProfileFactory(user=user_gql_client.user)
-
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -136,15 +129,13 @@ def test_normal_user_can_update_profile_without_email(
     }
 
     mutation = t.substitute(nickname=profile_data["nickname"],)
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert executed["data"] == expected_data
 
 
-def test_normal_user_can_add_email(rf, user_gql_client, email_data):
+def test_normal_user_can_add_email(user_gql_client, email_data):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     email = profile.emails.first()
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -211,14 +202,12 @@ def test_normal_user_can_add_email(rf, user_gql_client, email_data):
         email_type=email_data["email_type"],
         primary=str(not email_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_cannot_add_invalid_email(rf, user_gql_client, email_data):
+def test_normal_user_cannot_add_invalid_email(user_gql_client, email_data):
     ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -255,18 +244,14 @@ def test_normal_user_cannot_add_invalid_email(rf, user_gql_client, email_data):
         email_type=email_data["email_type"],
         primary=str(not email_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert "code" in executed["errors"][0]["extensions"]
     assert executed["errors"][0]["extensions"]["code"] == INVALID_EMAIL_FORMAT_ERROR
 
 
-def test_normal_user_cannot_update_email_to_invalid_format(
-    rf, user_gql_client, email_data
-):
+def test_normal_user_cannot_update_email_to_invalid_format(user_gql_client, email_data):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     email = profile.emails.first()
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -305,15 +290,13 @@ def test_normal_user_cannot_update_email_to_invalid_format(
         email_type=email_data["email_type"],
         primary=str(email_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert "code" in executed["errors"][0]["extensions"]
     assert executed["errors"][0]["extensions"]["code"] == INVALID_EMAIL_FORMAT_ERROR
 
 
-def test_normal_user_can_add_phone(rf, user_gql_client, phone_data):
+def test_normal_user_can_add_phone(user_gql_client, phone_data):
     ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -370,14 +353,12 @@ def test_normal_user_can_add_phone(rf, user_gql_client, phone_data):
         phone_type=phone_data["phone_type"],
         primary=str(phone_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_add_address(rf, user_gql_client, address_data):
+def test_normal_user_can_add_address(user_gql_client, address_data):
     ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -446,15 +427,13 @@ def test_normal_user_can_add_address(rf, user_gql_client, address_data):
         address_type=address_data["address_type"],
         primary=str(address_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_update_address(rf, user_gql_client, address_data):
+def test_normal_user_can_update_address(user_gql_client, address_data):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     address = AddressFactory(profile=profile)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -523,15 +502,13 @@ def test_normal_user_can_update_address(rf, user_gql_client, address_data):
         address_type=address_data["address_type"],
         primary=str(address_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_update_email(rf, user_gql_client, email_data):
+def test_normal_user_can_update_email(user_gql_client, email_data):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     email = profile.emails.first()
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -592,15 +569,13 @@ def test_normal_user_can_update_email(rf, user_gql_client, email_data):
         email_type=email_data["email_type"],
         primary=str(email_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_update_phone(rf, user_gql_client, phone_data):
+def test_normal_user_can_update_phone(user_gql_client, phone_data):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     phone = PhoneFactory(profile=profile)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -661,16 +636,14 @@ def test_normal_user_can_update_phone(rf, user_gql_client, phone_data):
         phone_type=phone_data["phone_type"],
         primary=str(phone_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_remove_email(rf, user_gql_client, email_data):
+def test_normal_user_can_remove_email(user_gql_client, email_data):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user, emails=2)
     primary_email = profile.emails.filter(primary=True).first()
     email = profile.emails.filter(primary=False).first()
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -728,16 +701,14 @@ def test_normal_user_can_remove_email(rf, user_gql_client, email_data):
         email_type=email_data["email_type"],
         primary=str(email_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_remove_all_emails(rf, user_gql_client, email_data):
+def test_normal_user_can_remove_all_emails(user_gql_client, email_data):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user, emails=2)
     primary_email = profile.emails.filter(primary=True).first()
     email = profile.emails.filter(primary=False).first()
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -775,15 +746,13 @@ def test_normal_user_can_remove_all_emails(rf, user_gql_client, email_data):
         primary_email_id=to_global_id(type="EmailNode", id=primary_email.id),
         email_id=to_global_id(type="EmailNode", id=email.id),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert executed["data"] == expected_data
 
 
-def test_normal_user_can_remove_phone(rf, user_gql_client, phone_data):
+def test_normal_user_can_remove_phone(user_gql_client, phone_data):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     phone = PhoneFactory(profile=profile)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -822,15 +791,13 @@ def test_normal_user_can_remove_phone(rf, user_gql_client, phone_data):
         phone_type=phone_data["phone_type"],
         primary=str(phone_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_remove_address(rf, user_gql_client, address_data):
+def test_normal_user_can_remove_address(user_gql_client, address_data):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     address = AddressFactory(profile=profile)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -869,19 +836,17 @@ def test_normal_user_can_remove_address(rf, user_gql_client, address_data):
         address_type=address_data["address_type"],
         primary=str(address_data["primary"]).lower(),
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
 def test_normal_user_can_change_primary_contact_details(
-    rf, user_gql_client, email_data, phone_data, address_data
+    user_gql_client, email_data, phone_data, address_data
 ):
     profile = ProfileFactory(user=user_gql_client.user)
     PhoneFactory(profile=profile, primary=True)
     EmailFactory(profile=profile, primary=True)
     AddressFactory(profile=profile, primary=True)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -974,18 +939,14 @@ def test_normal_user_can_change_primary_contact_details(
         address_type=address_data["address_type"],
         primary="true",
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_update_primary_contact_details(
-    rf, user_gql_client, email_data
-):
+def test_normal_user_can_update_primary_contact_details(user_gql_client, email_data):
     profile = ProfileFactory(user=user_gql_client.user)
     email = EmailFactory(profile=profile, primary=False)
     email_2 = EmailFactory(profile=profile, primary=True)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -1054,14 +1015,11 @@ def test_normal_user_can_update_primary_contact_details(
         email_type=email_data["email_type"],
         primary="true",
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_update_sensitive_data(rf, user_gql_client):
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
-
+def test_normal_user_can_update_sensitive_data(user_gql_client):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     SensitiveDataFactory(profile=profile, ssn="010199-1234")
 
@@ -1101,17 +1059,15 @@ def test_normal_user_can_update_sensitive_data(rf, user_gql_client):
             }
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert dict(executed["data"]) == expected_data
 
 
-def test_normal_user_can_update_subscriptions_via_profile(rf, user_gql_client):
+def test_normal_user_can_update_subscriptions_via_profile(user_gql_client):
     ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     category = SubscriptionTypeCategoryFactory()
     type_1 = SubscriptionTypeFactory(subscription_type_category=category, code="TEST-1")
     type_2 = SubscriptionTypeFactory(subscription_type_category=category, code="TEST-2")
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     t = Template(
         """
@@ -1187,5 +1143,5 @@ def test_normal_user_can_update_subscriptions_via_profile(rf, user_gql_client):
         type_2_id=to_global_id(type="SubscriptionTypeNode", id=type_2.id),
         type_2_enabled="false",
     )
-    executed = user_gql_client.execute(mutation, context=request)
+    executed = user_gql_client.execute(mutation)
     assert dict(executed["data"]) == expected_data

--- a/services/tests/test_services_graphql_api.py
+++ b/services/tests/test_services_graphql_api.py
@@ -10,10 +10,8 @@ from services.tests.factories import ProfileFactory, ServiceConnectionFactory
 
 
 def test_normal_user_can_query_own_services(
-    rf, user_gql_client, service, allowed_data_field_factory
+    user_gql_client, service, allowed_data_field_factory
 ):
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
     profile = ProfileFactory(user=user_gql_client.user)
     first_field = allowed_data_field_factory()
     second_field = allowed_data_field_factory()
@@ -80,7 +78,7 @@ def test_normal_user_can_query_own_services(
             }
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert executed["data"] == expected_data
 
 
@@ -230,11 +228,9 @@ def test_normal_user_cannot_add_service_multiple_times_mutation(
 
 
 def test_not_identifying_service_for_add_service_connection_produces_service_not_identified_error(
-    rf, user_gql_client
+    user_gql_client,
 ):
     ProfileFactory(user=user_gql_client.user)
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     query = """
         mutation {
@@ -251,21 +247,19 @@ def test_not_identifying_service_for_add_service_connection_produces_service_not
         }
     """
 
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
 
     assert_match_error_code(executed, SERVICE_NOT_IDENTIFIED_ERROR)
 
 
 def test_normal_user_can_query_own_services_gdpr_api_scopes(
-    rf, user_gql_client, service_factory,
+    user_gql_client, service_factory,
 ):
     query_scope = "query_scope"
     delete_scope = "delete_scope"
     service = service_factory(
         gdpr_query_scope=query_scope, gdpr_delete_scope=delete_scope
     )
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
     profile = ProfileFactory(user=user_gql_client.user)
 
     ServiceConnectionFactory(profile=profile, service=service)
@@ -305,6 +299,6 @@ def test_normal_user_can_query_own_services_gdpr_api_scopes(
             }
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
 
     assert dict(executed["data"]) == expected_data

--- a/subscriptions/tests/test_subscriptions_graphql_api.py
+++ b/subscriptions/tests/test_subscriptions_graphql_api.py
@@ -1,5 +1,5 @@
 def test_normal_user_can_query_subscription_types_grouped_by_categories(  # noqa: E302
-    rf, user_gql_client, subscription_type_factory, subscription_type_category
+    user_gql_client, subscription_type_factory, subscription_type_category
 ):
     type_1 = subscription_type_factory(
         subscription_type_category=subscription_type_category
@@ -7,8 +7,6 @@ def test_normal_user_can_query_subscription_types_grouped_by_categories(  # noqa
     type_2 = subscription_type_factory(
         subscription_type_category=subscription_type_category
     )
-    request = rf.post("/graphql")
-    request.user = user_gql_client.user
 
     query = """
         query {
@@ -63,6 +61,6 @@ def test_normal_user_can_query_subscription_types_grouped_by_categories(  # noqa
             ]
         }
     }
-    executed = user_gql_client.execute(query, context=request)
+    executed = user_gql_client.execute(query)
     assert "errors" not in executed
     assert dict(executed["data"]) == expected_data


### PR DESCRIPTION
Move some GraphQL request test setup into the test client. Namely it now constructs an HTTP request object (used as the `context` in the GraphQL query handling), and inserts a `User`, a `UserAuthorization`, and a `Service` into it. This mimics more closely the way how requests are handled in the real world for **all** tests now.

There are a few quite big commits in this PR, but they mostly just repeat the same 3-4 line change (mostly removing lines) over and over again throughout the test code.