### PR TITLE
View some relations as autocomplete fields

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -43,6 +43,7 @@ class RepresentativeAdmin(admin.StackedInline):
     fk_name = "representative"
     verbose_name = "Representative"
     verbose_name_plural = "Representing"
+    autocomplete_fields = ("representee",)
 
 
 class RepresenteeAdmin(admin.StackedInline):
@@ -51,6 +52,7 @@ class RepresenteeAdmin(admin.StackedInline):
     fk_name = "representee"
     verbose_name = "Representative"
     verbose_name_plural = "Represented by"
+    autocomplete_fields = ("representative",)
 
 
 class AlwaysChangedModelForm(ModelForm):
@@ -177,6 +179,14 @@ class ExtendedProfileAdmin(VersionAdmin):
     ]
     change_list_template = "admin/profiles/profiles_changelist.html"
     list_filter = ("service_connections__service",)
+    autocomplete_fields = ("user",)
+    search_fields = (
+        "id",
+        "first_name",
+        "last_name",
+        "verified_personal_information__first_name",
+        "verified_personal_information__last_name",
+    )
 
     def get_urls(self):
         urls = super().get_urls()

--- a/profiles/tests/test_admin.py
+++ b/profiles/tests/test_admin.py
@@ -1,8 +1,10 @@
 from django.forms.models import inlineformset_factory
+from django.urls import reverse
 
 from ..admin import EmailFormSet
 from ..enums import EmailType
 from ..models import Email, Profile
+from .factories import ProfileFactory
 
 
 def test_profile_should_have_exactly_one_primary_email(profile):
@@ -54,3 +56,18 @@ def test_profile_should_not_be_valid_with_two_or_more_primary_emails(profile):
     }
     formset = email_formset(data, prefix="emails", instance=profile)
     assert not formset.is_valid()
+
+
+def test_admin_profile_change_view_query_count_not_too_big(
+    admin_client, django_assert_max_num_queries, profile
+):
+    view_profile_url = reverse("admin:profiles_profile_change", args=(profile.pk,))
+
+    with django_assert_max_num_queries(50):
+        admin_client.get(view_profile_url)
+
+    # Add 100 profiles
+    ProfileFactory.create_batch(100)
+
+    with django_assert_max_num_queries(50):
+        admin_client.get(view_profile_url)


### PR DESCRIPTION
Django Admin automatically populates a dropdown for relations, but when there are thousands of instances the dropdown generation generates many SQL queries.

By displaying the fields as autocomplete the dropdown is not generated right away.

Refs HP-561