### PR TITLE
Audit log actor service's name

### DIFF
--- a/open_city_profile/tests/graphql_test_helpers.py
+++ b/open_city_profile/tests/graphql_test_helpers.py
@@ -79,8 +79,16 @@ def do_graphql_call(
     return body.get("data"), body.get("errors")
 
 
-def do_graphql_call_as_user(live_server, user, query=_QUERY, extra_request_args=dict()):
+def do_graphql_call_as_user(
+    live_server, user, service=None, query=_QUERY, extra_request_args=dict()
+):
     claims = {"sub": str(user.uuid)}
+
+    if service is not None:
+        service_client_id = service.client_ids.first()
+        if service_client_id:
+            claims["azp"] = service_client_id.client_id
+
     return do_graphql_call(
         live_server,
         BearerTokenAuth(extra_claims=claims),

--- a/profiles/audit_log.py
+++ b/profiles/audit_log.py
@@ -78,10 +78,7 @@ def log(action, instance):
 
         service = get_current_service()
         if service:
-            message["audit_event"]["actor_service"] = {
-                "id": str(service.name),
-                "name": str(service.label),
-            }
+            message["audit_event"]["actor"]["service_name"] = service.name
 
         ip_address = get_original_client_ip()
         if ip_address:

--- a/profiles/decorators.py
+++ b/profiles/decorators.py
@@ -50,7 +50,7 @@ def staff_required(required_permission="view"):
                 )
 
             service = context.service
-            set_current_service(service.service_type)
+            set_current_service(service)
 
             try:
                 if context.user.has_perm(

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -170,7 +170,7 @@ def test_actor_is_resolved_in_graphql_call(
 ):
     user = profile.user
 
-    do_graphql_call_as_user(live_server, user, MY_PROFILE_QUERY)
+    do_graphql_call_as_user(live_server, user, query=MY_PROFILE_QUERY)
     audit_logs = cap_audit_log.get_logs()
     assert len(audit_logs) == 1
     log_message = audit_logs[0]
@@ -187,7 +187,7 @@ class TestIPAddressLogging:
         user = profile.user
 
         do_graphql_call_as_user(
-            live_server, user, MY_PROFILE_QUERY, extra_request_args=request_args
+            live_server, user, query=MY_PROFILE_QUERY, extra_request_args=request_args
         )
         audit_logs = cap_audit_log.get_logs()
         assert len(audit_logs) == 1

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -208,11 +208,8 @@ def test_actor_service(live_server, user, group, service_client_id, cap_audit_lo
     assert len(audit_logs) == 1
     log_message = audit_logs[0]
     assert_common_fields(log_message, profile, "READ", actor_role="ADMIN")
-    service_log = log_message["audit_event"]["actor_service"]
-    assert service_log == {
-        "id": service.service_type.name,
-        "name": service.service_type.label,
-    }
+    actor_log = log_message["audit_event"]["actor"]
+    assert actor_log["service_name"] == service.name
 
 
 class TestIPAddressLogging:


### PR DESCRIPTION
The obsolete `service_type` field of `Service` is not used for audit logging anymore. Instead the `name` is used, which is a mandatory field in `Service`.

Also the actor's service information is now included within the "actor" element in the audit log. There is no "actor_service" element anymore.