### PR TITLE
More audit log changes

### DIFF
--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -49,7 +49,6 @@ env = environ.Env(
     FIELD_ENCRYPTION_KEYS=(list, []),
     VERSION=(str, None),
     AUDIT_LOGGING_ENABLED=(bool, False),
-    AUDIT_LOG_USERNAME=(bool, False),
     AUDIT_LOG_FILENAME=(str, ""),
     ENABLE_GRAPHIQL=(bool, False),
     FORCE_SCRIPT_NAME=(str, ""),
@@ -328,7 +327,6 @@ if "SECRET_KEY" not in locals():
             )
 
 AUDIT_LOGGING_ENABLED = env.bool("AUDIT_LOGGING_ENABLED")
-AUDIT_LOG_USERNAME = env.bool("AUDIT_LOG_USERNAME")
 AUDIT_LOG_FILENAME = env("AUDIT_LOG_FILENAME")
 
 if AUDIT_LOG_FILENAME:

--- a/profiles/audit_log.py
+++ b/profiles/audit_log.py
@@ -37,10 +37,6 @@ def _format_user_data(audit_event, field_name, user):
         audit_event[field_name]["user_id"] = (
             str(user.uuid) if hasattr(user, "uuid") else None
         )
-        if settings.AUDIT_LOG_USERNAME:
-            audit_event[field_name]["user_name"] = (
-                user.username if hasattr(user, "username") else None
-            )
 
 
 def log(action, instance):

--- a/profiles/audit_log.py
+++ b/profiles/audit_log.py
@@ -78,8 +78,6 @@ def log(action, instance):
 
         ip_address = get_original_client_ip()
         if ip_address:
-            message["audit_event"]["profilebe"] = {
-                "ip_address": ip_address,
-            }
+            message["audit_event"]["actor"]["ip_address"] = ip_address
 
         logger.info(json.dumps(message))

--- a/profiles/audit_log.py
+++ b/profiles/audit_log.py
@@ -61,10 +61,7 @@ def log(action, instance):
                 "date_time": f"{current_time.replace(tzinfo=None).isoformat(sep='T', timespec='milliseconds')}Z",
                 "actor": {"role": _resolve_role(current_user, profile)},
                 "operation": action,
-                "target": {
-                    "profile_id": profile_id,
-                    "profile_part": _profile_part(instance),
-                },
+                "target": {"id": profile_id, "type": _profile_part(instance)},
             }
         }
 

--- a/profiles/tests/conftest.py
+++ b/profiles/tests/conftest.py
@@ -88,11 +88,6 @@ def setup_audit_log(settings):
     settings.AUDIT_LOGGING_ENABLED = False
 
 
-@pytest.fixture(autouse=True)
-def setup_log_username(settings):
-    settings.AUDIT_LOG_USERNAME = False
-
-
 class ProfileWithVerifiedPersonalInformationTestBase:
     ADDRESS_FIELD_NAMES = {
         "permanent_address": ["street_address", "postal_code", "post_office"],

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -57,8 +57,8 @@ def assert_common_fields(
     assert_almost_equal(log_dt, now_dt, timedelta(milliseconds=leeway_ms))
 
     expected_target = {
-        "profile_id": str(target_profile.pk),
-        "profile_part": target_profile_part,
+        "id": str(target_profile.pk),
+        "type": target_profile_part,
         "user_id": str(target_profile.user.uuid),
     }
     assert audit_event["target"] == expected_target

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -215,7 +215,7 @@ class TestIPAddressLogging:
         audit_logs = cap_audit_log.get_logs()
         assert len(audit_logs) == 1
         log_message = audit_logs[0]
-        assert log_message["audit_event"]["profilebe"]["ip_address"] == expected_ip
+        assert log_message["audit_event"]["actor"]["ip_address"] == expected_ip
 
     @pytest.mark.parametrize(
         "header", ["12.23.34.45", "12.23.34.45,1.1.1.1", "12.23.34.45, 1.1.1.1"]

--- a/services/tests/factories.py
+++ b/services/tests/factories.py
@@ -14,8 +14,15 @@ from ..enums import ServiceType
 class ServiceFactory(factory.django.DjangoModelFactory):
     service_type = ServiceType.BERTH
     name = factory.Sequence(lambda n: "service %d" % n)
-    title = "Berth"
-    description = "Service for Berth Reservations"
+
+    @factory.lazy_attribute
+    def title(self):
+        return f"{self.name} title"
+
+    @factory.lazy_attribute
+    def description(self):
+        return f"{self.name} description"
+
     gdpr_url = ""
 
     class Meta:


### PR DESCRIPTION
- `user_name` removed from `actor` and `target` elements.
- moved `ip_address` into the `actor` element  (was previously under the `profilebe` element).
- in the `target` element:
  - `profile_id` renamed to `id`
  - `profile_part` renamed to `type`
- the `profilebe` element doesn’t exist anymore.