### PR TITLE
Add audit logging to verified personal information parts

### DIFF
--- a/profiles/audit_log.py
+++ b/profiles/audit_log.py
@@ -49,7 +49,11 @@ def log(action, instance):
 
         current_time = datetime.now(tz=timezone.utc)
         current_user = get_current_user()
-        profile = instance.resolve_profile()
+        profile = (
+            instance.profile
+            if hasattr(instance, "profile")
+            else instance.resolve_profile()
+        )
         profile_id = str(profile.pk) if profile else None
         target_user = profile.user if profile and profile.user else None
 

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -261,6 +261,8 @@ class VerifiedPersonalInformation(ValidateOnSaveModel, NullsToEmptyStringsModel)
         help_text="Official municipality of residence in Finland as an official number.",
     )
 
+    audit_log = True
+
     class Meta:
         permissions = [
             (

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -293,6 +293,11 @@ class VerifiedPersonalInformationPermanentAddress(EncryptedAddress):
         related_name=RELATED_NAME,
     )
 
+    audit_log = True
+
+    def resolve_profile(self):
+        return self.verified_personal_information.profile
+
 
 class VerifiedPersonalInformationTemporaryAddress(EncryptedAddress):
     RELATED_NAME = "temporary_address"

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -308,6 +308,11 @@ class VerifiedPersonalInformationTemporaryAddress(EncryptedAddress):
         related_name=RELATED_NAME,
     )
 
+    audit_log = True
+
+    def resolve_profile(self):
+        return self.verified_personal_information.profile
+
 
 class VerifiedPersonalInformationPermanentForeignAddress(
     ValidateOnSaveModel, UpdateMixin, NullsToEmptyStringsModel
@@ -334,8 +339,13 @@ class VerifiedPersonalInformationPermanentForeignAddress(
         related_name=RELATED_NAME,
     )
 
+    audit_log = True
+
     def is_empty(self):
         return not (self.street_address or self.additional_address or self.country_code)
+
+    def resolve_profile(self):
+        return self.verified_personal_information.profile
 
 
 class DivisionOfInterest(models.Model):

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -143,6 +143,20 @@ def vpi_factory_with_addresses(*wanted_address_models):
             "verified personal information permanent address",
             ["verified personal information"],
         ),
+        (
+            vpi_factory_with_addresses(VerifiedPersonalInformationTemporaryAddress),
+            "verified_personal_information__temporary_address",
+            "verified personal information temporary address",
+            ["verified personal information"],
+        ),
+        (
+            vpi_factory_with_addresses(
+                VerifiedPersonalInformationPermanentForeignAddress
+            ),
+            "verified_personal_information__permanent_foreign_address",
+            "verified personal information permanent foreign address",
+            ["verified personal information"],
+        ),
     ]
 )
 def profile_with_related(request):

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -59,7 +59,7 @@ def assert_common_fields(
 ):
     now_dt = datetime.now(tz=timezone.utc)
     now_ms_timestamp = int(now_dt.timestamp() * 1000)
-    leeway_ms = 20
+    leeway_ms = 50
 
     if not isinstance(log_messages, list):
         log_messages = [log_messages]

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -13,7 +13,11 @@ from open_city_profile.tests.graphql_test_helpers import do_graphql_call_as_user
 from profiles.models import Profile
 from services.tests.factories import ServiceConnectionFactory
 
-from .factories import ProfileFactory, SensitiveDataFactory
+from .factories import (
+    ProfileFactory,
+    SensitiveDataFactory,
+    VerifiedPersonalInformationFactory,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -78,6 +82,11 @@ class ProfileWithRelated:
     params=[
         (ProfileFactory, None, None),
         (SensitiveDataFactory, "sensitivedata", "sensitive data"),
+        (
+            VerifiedPersonalInformationFactory,
+            "verified_personal_information",
+            "verified personal information",
+        ),
     ]
 )
 def profile_with_related(request):


### PR DESCRIPTION
When `Profile`'s `VerifiedPersonalInformation`, or any of its addresses, is touched (in CRUD terms), a line is added to the audit log.

The production code changes are quite small. The tests however experienced a bigger refactoring.