### PR TITLE
Avoid unnecessary database updates with empty addresses

### DIFF
--- a/profiles/migrations/0031_verifiedpersonalinformationtemporaryaddress.py
+++ b/profiles/migrations/0031_verifiedpersonalinformationtemporaryaddress.py
@@ -3,7 +3,6 @@
 from django.db import migrations, models
 import django.db.models.deletion
 import encrypted_fields.fields
-import utils.models
 
 
 class Migration(migrations.Migration):
@@ -53,6 +52,5 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={"abstract": False,},
-            bases=(models.Model, utils.models.UpdateMixin),
         ),
     ]

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -20,7 +20,6 @@ from users.models import User
 from utils.models import (
     NullsToEmptyStringsModel,
     SerializableMixin,
-    UpdateMixin,
     UUIDModel,
     ValidateOnSaveModel,
 )
@@ -272,7 +271,7 @@ class VerifiedPersonalInformation(ValidateOnSaveModel, NullsToEmptyStringsModel)
         ]
 
 
-class EncryptedAddress(ValidateOnSaveModel, UpdateMixin, NullsToEmptyStringsModel):
+class EncryptedAddress(ValidateOnSaveModel, NullsToEmptyStringsModel):
     street_address = fields.EncryptedCharField(max_length=1024, blank=True)
     postal_code = fields.EncryptedCharField(max_length=1024, blank=True)
     post_office = fields.EncryptedCharField(max_length=1024, blank=True)
@@ -315,7 +314,7 @@ class VerifiedPersonalInformationTemporaryAddress(EncryptedAddress):
 
 
 class VerifiedPersonalInformationPermanentForeignAddress(
-    ValidateOnSaveModel, UpdateMixin, NullsToEmptyStringsModel
+    ValidateOnSaveModel, NullsToEmptyStringsModel
 ):
     RELATED_NAME = "permanent_foreign_address"
 

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -899,24 +899,23 @@ class CreateOrUpdateProfileWithVerifiedPersonalInformationMutation(graphene.Muta
 
         for address_type in address_types:
             address_input = address_type["input"]
-            if address_input:
-                address_name = address_type["name"]
-                address_model = address_type["model"]
-                try:
-                    address = getattr(information, address_name)
-                    for field, value in address_input.items():
-                        setattr(address, field, value)
+            if not address_input:
+                continue
 
-                    if address.is_empty():
-                        address.delete()
-                    else:
-                        address.save(update_fields=address_input.keys())
-                except address_model.DoesNotExist:
-                    address = address_model(
-                        verified_personal_information=information, **address_input
-                    )
-                    if not address.is_empty():
-                        address.save()
+            address_name = address_type["name"]
+            address_model = address_type["model"]
+            try:
+                address = getattr(information, address_name)
+            except address_model.DoesNotExist:
+                address = address_model(verified_personal_information=information)
+
+            for field, value in address_input.items():
+                setattr(address, field, value)
+
+            if not address.is_empty():
+                address.save()
+            elif address.id:
+                address.delete()
 
         service_client_id = input.pop("service_client_id", None)
         if service_client_id:

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -905,12 +905,14 @@ class CreateOrUpdateProfileWithVerifiedPersonalInformationMutation(graphene.Muta
                 try:
                     address = getattr(information, address_name)
                     address.update(address_input)
+                    if address.is_empty():
+                        address.delete()
                 except address_model.DoesNotExist:
-                    address = address_model.objects.create(
+                    address = address_model(
                         verified_personal_information=information, **address_input
                     )
-                if address.is_empty():
-                    address.delete()
+                    if not address.is_empty():
+                        address.save()
 
         service_client_id = input.pop("service_client_id", None)
         if service_client_id:

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -904,9 +904,13 @@ class CreateOrUpdateProfileWithVerifiedPersonalInformationMutation(graphene.Muta
                 address_model = address_type["model"]
                 try:
                     address = getattr(information, address_name)
-                    address.update(address_input)
+                    for field, value in address_input.items():
+                        setattr(address, field, value)
+
                     if address.is_empty():
                         address.delete()
+                    else:
+                        address.save(update_fields=address_input.keys())
                 except address_model.DoesNotExist:
                     address = address_model(
                         verified_personal_information=information, **address_input

--- a/utils/models.py
+++ b/utils/models.py
@@ -129,13 +129,6 @@ class SerializableMixin(models.Model):
         }
 
 
-class UpdateMixin:
-    def update(self, data):
-        for field, value in data.items():
-            setattr(self, field, value)
-        self.save(update_fields=data.keys())
-
-
 class ValidateOnSaveModel(models.Model):
     class Meta:
         abstract = True


### PR DESCRIPTION
The previous version of the code created or updated empty address models of `VerifiedPersonalInformation` into the database unnecessarily. Not any more.