### PR TITLE
Add primary email input to createOrUpdateProfileWithVerifiedPersonalInformation mutation

### DIFF
--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -175,6 +175,10 @@ type DeleteMyProfileMutationPayload {
   clientMutationId: String
 }
 
+input EmailInput {
+  email: String!
+}
+
 type EmailNode implements Node {
   primary: Boolean!
   id: ID!
@@ -311,6 +315,7 @@ type ProfileNodeEdge {
 
 input ProfileWithVerifiedPersonalInformationInput {
   verifiedPersonalInformation: VerifiedPersonalInformationInput!
+  primaryEmail: EmailInput
 }
 
 type ProfileWithVerifiedPersonalInformationOutput implements Node {

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -890,9 +890,12 @@ class CreateOrUpdateProfileWithVerifiedPersonalInformationMutation(graphene.Muta
     def _handle_primary_email(profile, primary_email_input):
         email_address = primary_email_input["email"]
 
-        profile.emails.create(
-            email=email_address, email_type=EmailType.NONE, primary=True,
-        )
+        email = profile.emails.create(email=email_address, email_type=EmailType.NONE)
+
+        profile.emails.update(primary=False)
+
+        email.primary = True
+        email.save()
 
     @staticmethod
     @permission_required("profiles.manage_verified_personal_information")

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -577,31 +577,27 @@ class TemporaryReadAccessTokenNode(DjangoObjectType):
         return self.expires_at()
 
 
-class EmailInput(graphene.InputObjectType):
+class CreateEmailInput(graphene.InputObjectType):
     primary = graphene.Boolean(description="Is this primary mail address.")
-
-
-class CreateEmailInput(EmailInput):
     email = graphene.String(description="Email address.", required=True)
     email_type = AllowedEmailType(description="Email address type.", required=True)
 
 
-class UpdateEmailInput(EmailInput):
+class UpdateEmailInput(graphene.InputObjectType):
+    primary = graphene.Boolean(description="Is this primary mail address.")
     id = graphene.ID(required=True)
     email = graphene.String(description="Email address.")
     email_type = AllowedEmailType(description="Email address type.")
 
 
-class PhoneInput(graphene.InputObjectType):
+class CreatePhoneInput(graphene.InputObjectType):
     primary = graphene.Boolean(description="Is this primary phone number.")
-
-
-class CreatePhoneInput(PhoneInput):
     phone = graphene.String(description="Phone number.", required=True)
     phone_type = AllowedPhoneType(description="Phone number type.", required=True)
 
 
-class UpdatePhoneInput(PhoneInput):
+class UpdatePhoneInput(graphene.InputObjectType):
+    primary = graphene.Boolean(description="Is this primary phone number.")
     id = graphene.ID(required=True)
     phone = graphene.String(description="Phone number.")
     phone_type = AllowedPhoneType(description="Phone number type.")

--- a/profiles/tests/conftest.py
+++ b/profiles/tests/conftest.py
@@ -88,17 +88,18 @@ def setup_audit_log(settings):
     settings.AUDIT_LOGGING_ENABLED = False
 
 
-class ProfileWithVerifiedPersonalInformationTestBase:
-    ADDRESS_FIELD_NAMES = {
-        "permanent_address": ["street_address", "postal_code", "post_office"],
-        "temporary_address": ["street_address", "postal_code", "post_office"],
-        "permanent_foreign_address": [
-            "street_address",
-            "additional_address",
-            "country_code",
-        ],
-    }
-    ADDRESS_TYPES = ADDRESS_FIELD_NAMES.keys()
+VERIFIED_PERSONAL_INFORMATION_ADDRESS_FIELD_NAMES = {
+    "permanent_address": ["street_address", "postal_code", "post_office"],
+    "temporary_address": ["street_address", "postal_code", "post_office"],
+    "permanent_foreign_address": [
+        "street_address",
+        "additional_address",
+        "country_code",
+    ],
+}
+VERIFIED_PERSONAL_INFORMATION_ADDRESS_TYPES = (
+    VERIFIED_PERSONAL_INFORMATION_ADDRESS_FIELD_NAMES.keys()
+)
 
 
 class TemporaryProfileReadAccessTokenTestBase:

--- a/profiles/tests/test_gql_create_or_update_profile_with_verified_personal_information_mutation.py
+++ b/profiles/tests/test_gql_create_or_update_profile_with_verified_personal_information_mutation.py
@@ -343,6 +343,20 @@ def test_existing_primary_email_remains_when_trying_to_set_the_same_email_as_a_p
     assert email.email_type == old_email.email_type
 
 
+@pytest.mark.parametrize(
+    "test_email", ("", " ", "not_an_email", " extra_white_space@address.example")
+)
+def test_deny_invalid_primary_email_address(test_email, user_gql_client):
+    user_id = uuid.uuid1()
+
+    input_data = primary_email_input_data(user_id, test_email)
+
+    executed = execute_mutation(input_data, user_gql_client)
+
+    assert_match_error_code(executed, "VALIDATION_ERROR")
+    assert executed["data"]["prof"] is None
+
+
 def service_input_data(user_id, service_client_id):
     user_id = str(user_id)
     return {

--- a/profiles/tests/test_gql_create_or_update_profile_with_verified_personal_information_mutation.py
+++ b/profiles/tests/test_gql_create_or_update_profile_with_verified_personal_information_mutation.py
@@ -15,390 +15,376 @@ from profiles.models import (
 )
 from services.enums import ServiceType
 
-from .conftest import ProfileWithVerifiedPersonalInformationTestBase
+from .conftest import (
+    VERIFIED_PERSONAL_INFORMATION_ADDRESS_FIELD_NAMES,
+    VERIFIED_PERSONAL_INFORMATION_ADDRESS_TYPES,
+)
 
 
-class TestProfileWithVerifiedPersonalInformationCreation(
-    ProfileWithVerifiedPersonalInformationTestBase
-):
-    @staticmethod
-    def execute_mutation(input_data, gql_client):
-        user = gql_client.user
+def execute_mutation(input_data, gql_client):
+    user = gql_client.user
 
-        assign_perm("profiles.manage_verified_personal_information", user)
+    assign_perm("profiles.manage_verified_personal_information", user)
 
-        query = """
-            mutation createOrUpdateProfileWithVerifiedPersonalInformation(
-                $input: CreateOrUpdateProfileWithVerifiedPersonalInformationMutationInput!
-            ) {
-                prof: createOrUpdateProfileWithVerifiedPersonalInformation(
-                    input: $input,
-                ) {
-                    profile {
-                        id,
-                    }
-                }
-            }
-        """
-
-        return gql_client.execute(query, variables={"input": input_data})
-
-    @staticmethod
-    def execute_successful_mutation(input_data, gql_client):
-        executed = TestProfileWithVerifiedPersonalInformationCreation.execute_mutation(
-            input_data, gql_client
-        )
-
-        global_profile_id = executed["data"]["prof"]["profile"]["id"]
-        profile_id = uuid.UUID(from_global_id(global_profile_id)[1])
-
-        return Profile.objects.get(pk=profile_id)
-
-    @staticmethod
-    def execute_successful_profile_creation_test(user_id, gql_client):
-        input_data = {
-            "userId": str(user_id),
-            "profile": {
-                "verifiedPersonalInformation": {
-                    "firstName": "John",
-                    "lastName": "Smith",
-                    "givenName": "Johnny",
-                    "nationalIdentificationNumber": "220202A1234",
-                    "email": "john.smith@domain.example",
-                    "municipalityOfResidence": "Helsinki",
-                    "municipalityOfResidenceNumber": "091",
-                    "permanentAddress": {
-                        "streetAddress": "Permanent Street 1",
-                        "postalCode": "12345",
-                        "postOffice": "Permanent City",
-                    },
-                    "temporaryAddress": {
-                        "streetAddress": "Temporary Street 2",
-                        "postalCode": "98765",
-                        "postOffice": "Temporary City",
-                    },
-                    "permanentForeignAddress": {
-                        "streetAddress": "〒100-8994",
-                        "additionalAddress": "東京都中央区八重洲1-5-3",
-                        "countryCode": "JP",
-                    },
-                },
-            },
-        }
-
-        profile = TestProfileWithVerifiedPersonalInformationCreation.execute_successful_mutation(
-            input_data, gql_client
-        )
-
-        assert profile.user.uuid == user_id
-        verified_personal_information = profile.verified_personal_information
-        assert verified_personal_information.first_name == "John"
-        assert verified_personal_information.last_name == "Smith"
-        assert verified_personal_information.given_name == "Johnny"
-        assert (
-            verified_personal_information.national_identification_number
-            == "220202A1234"
-        )
-        assert verified_personal_information.email == "john.smith@domain.example"
-        assert verified_personal_information.municipality_of_residence == "Helsinki"
-        assert verified_personal_information.municipality_of_residence_number == "091"
-        permanent_address = verified_personal_information.permanent_address
-        assert permanent_address.street_address == "Permanent Street 1"
-        assert permanent_address.postal_code == "12345"
-        assert permanent_address.post_office == "Permanent City"
-        temporary_address = verified_personal_information.temporary_address
-        assert temporary_address.street_address == "Temporary Street 2"
-        assert temporary_address.postal_code == "98765"
-        assert temporary_address.post_office == "Temporary City"
-        permanent_foreign_address = (
-            verified_personal_information.permanent_foreign_address
-        )
-        assert permanent_foreign_address.street_address == "〒100-8994"
-        assert permanent_foreign_address.additional_address == "東京都中央区八重洲1-5-3"
-        assert permanent_foreign_address.country_code == "JP"
-
-    def test_profile_with_verified_personal_information_can_be_created(
-        self, user_gql_client
-    ):
-        self.execute_successful_profile_creation_test(uuid.uuid1(), user_gql_client)
-
-    def test_manage_verified_personal_information_permission_is_needed(
-        self, user_gql_client
-    ):
-        query = """
-        mutation {
-            createOrUpdateProfileWithVerifiedPersonalInformation(
-                input: {
-                    userId: "03117666-117D-4F6B-80B1-A3A92B389711",
-                    profile: {
-                        verifiedPersonalInformation: {
-                        }
-                    }
-                }
+    query = """
+        mutation createOrUpdateProfileWithVerifiedPersonalInformation(
+            $input: CreateOrUpdateProfileWithVerifiedPersonalInformationMutationInput!
+        ) {
+            prof: createOrUpdateProfileWithVerifiedPersonalInformation(
+                input: $input,
             ) {
                 profile {
                     id,
                 }
             }
         }
-        """
+    """
 
-        executed = user_gql_client.execute(query)
-        assert executed["errors"][0]["extensions"]["code"] == "PERMISSION_DENIED_ERROR"
+    return gql_client.execute(query, variables={"input": input_data})
 
-    def test_existing_user_is_used(self, user, user_gql_client):
-        self.execute_successful_profile_creation_test(user.uuid, user_gql_client)
 
-    def test_existing_profile_without_verified_personal_information_is_updated(
-        self, profile, user_gql_client
-    ):
-        self.execute_successful_profile_creation_test(
-            profile.user.uuid, user_gql_client
-        )
+def execute_successful_mutation(input_data, gql_client):
+    executed = execute_mutation(input_data, gql_client)
 
-    def test_existing_profile_with_verified_personal_information_is_updated(
-        self, profile_with_verified_personal_information, user_gql_client
-    ):
-        self.execute_successful_profile_creation_test(
-            profile_with_verified_personal_information.user.uuid, user_gql_client,
-        )
+    global_profile_id = executed["data"]["prof"]["profile"]["id"]
+    profile_id = uuid.UUID(from_global_id(global_profile_id)[1])
 
-    def test_all_basic_fields_can_be_set_to_null(self, user_gql_client):
-        input_data = {
-            "userId": "03117666-117D-4F6B-80B1-A3A92B389711",
-            "profile": {
-                "verifiedPersonalInformation": {
-                    "firstName": None,
-                    "lastName": None,
-                    "givenName": None,
-                    "nationalIdentificationNumber": None,
-                    "email": None,
-                    "municipalityOfResidence": None,
-                    "municipalityOfResidenceNumber": None,
+    return Profile.objects.get(pk=profile_id)
+
+
+def execute_successful_profile_creation_test(user_id, gql_client):
+    input_data = {
+        "userId": str(user_id),
+        "profile": {
+            "verifiedPersonalInformation": {
+                "firstName": "John",
+                "lastName": "Smith",
+                "givenName": "Johnny",
+                "nationalIdentificationNumber": "220202A1234",
+                "email": "john.smith@domain.example",
+                "municipalityOfResidence": "Helsinki",
+                "municipalityOfResidenceNumber": "091",
+                "permanentAddress": {
+                    "streetAddress": "Permanent Street 1",
+                    "postalCode": "12345",
+                    "postOffice": "Permanent City",
+                },
+                "temporaryAddress": {
+                    "streetAddress": "Temporary Street 2",
+                    "postalCode": "98765",
+                    "postOffice": "Temporary City",
+                },
+                "permanentForeignAddress": {
+                    "streetAddress": "〒100-8994",
+                    "additionalAddress": "東京都中央区八重洲1-5-3",
+                    "countryCode": "JP",
                 },
             },
+        },
+    }
+
+    profile = execute_successful_mutation(input_data, gql_client)
+
+    assert profile.user.uuid == user_id
+    verified_personal_information = profile.verified_personal_information
+    assert verified_personal_information.first_name == "John"
+    assert verified_personal_information.last_name == "Smith"
+    assert verified_personal_information.given_name == "Johnny"
+    assert verified_personal_information.national_identification_number == "220202A1234"
+    assert verified_personal_information.email == "john.smith@domain.example"
+    assert verified_personal_information.municipality_of_residence == "Helsinki"
+    assert verified_personal_information.municipality_of_residence_number == "091"
+    permanent_address = verified_personal_information.permanent_address
+    assert permanent_address.street_address == "Permanent Street 1"
+    assert permanent_address.postal_code == "12345"
+    assert permanent_address.post_office == "Permanent City"
+    temporary_address = verified_personal_information.temporary_address
+    assert temporary_address.street_address == "Temporary Street 2"
+    assert temporary_address.postal_code == "98765"
+    assert temporary_address.post_office == "Temporary City"
+    permanent_foreign_address = verified_personal_information.permanent_foreign_address
+    assert permanent_foreign_address.street_address == "〒100-8994"
+    assert permanent_foreign_address.additional_address == "東京都中央区八重洲1-5-3"
+    assert permanent_foreign_address.country_code == "JP"
+
+
+def test_profile_with_verified_personal_information_can_be_created(user_gql_client):
+    execute_successful_profile_creation_test(uuid.uuid1(), user_gql_client)
+
+
+def test_manage_verified_personal_information_permission_is_needed(user_gql_client):
+    query = """
+    mutation {
+        createOrUpdateProfileWithVerifiedPersonalInformation(
+            input: {
+                userId: "03117666-117D-4F6B-80B1-A3A92B389711",
+                profile: {
+                    verifiedPersonalInformation: {
+                    }
+                }
+            }
+        ) {
+            profile {
+                id,
+            }
         }
+    }
+    """
 
-        profile = self.execute_successful_mutation(input_data, user_gql_client)
+    executed = user_gql_client.execute(query)
+    assert executed["errors"][0]["extensions"]["code"] == "PERMISSION_DENIED_ERROR"
 
-        verified_personal_information = profile.verified_personal_information
-        assert verified_personal_information.first_name == ""
-        assert verified_personal_information.last_name == ""
-        assert verified_personal_information.given_name == ""
-        assert verified_personal_information.national_identification_number == ""
-        assert verified_personal_information.email == ""
-        assert verified_personal_information.municipality_of_residence == ""
-        assert verified_personal_information.municipality_of_residence_number == ""
 
-    @pytest.mark.parametrize(
-        "address_type", ProfileWithVerifiedPersonalInformationTestBase.ADDRESS_TYPES,
+def test_existing_user_is_used(user, user_gql_client):
+    execute_successful_profile_creation_test(user.uuid, user_gql_client)
+
+
+def test_existing_profile_without_verified_personal_information_is_updated(
+    profile, user_gql_client
+):
+    execute_successful_profile_creation_test(profile.user.uuid, user_gql_client)
+
+
+def test_existing_profile_with_verified_personal_information_is_updated(
+    profile_with_verified_personal_information, user_gql_client
+):
+    execute_successful_profile_creation_test(
+        profile_with_verified_personal_information.user.uuid, user_gql_client,
     )
-    @pytest.mark.parametrize("address_field_index_to_nullify", [0, 1, 2])
-    def test_address_fields_can_be_set_to_null(
-        self,
-        profile_with_verified_personal_information,
+
+
+def test_all_basic_fields_can_be_set_to_null(user_gql_client):
+    input_data = {
+        "userId": "03117666-117D-4F6B-80B1-A3A92B389711",
+        "profile": {
+            "verifiedPersonalInformation": {
+                "firstName": None,
+                "lastName": None,
+                "givenName": None,
+                "nationalIdentificationNumber": None,
+                "email": None,
+                "municipalityOfResidence": None,
+                "municipalityOfResidenceNumber": None,
+            },
+        },
+    }
+
+    profile = execute_successful_mutation(input_data, user_gql_client)
+
+    verified_personal_information = profile.verified_personal_information
+    assert verified_personal_information.first_name == ""
+    assert verified_personal_information.last_name == ""
+    assert verified_personal_information.given_name == ""
+    assert verified_personal_information.national_identification_number == ""
+    assert verified_personal_information.email == ""
+    assert verified_personal_information.municipality_of_residence == ""
+    assert verified_personal_information.municipality_of_residence_number == ""
+
+
+@pytest.mark.parametrize(
+    "address_type", VERIFIED_PERSONAL_INFORMATION_ADDRESS_TYPES,
+)
+@pytest.mark.parametrize("address_field_index_to_nullify", [0, 1, 2])
+def test_address_fields_can_be_set_to_null(
+    profile_with_verified_personal_information,
+    address_type,
+    address_field_index_to_nullify,
+    user_gql_client,
+):
+    address_field_names = VERIFIED_PERSONAL_INFORMATION_ADDRESS_FIELD_NAMES[
+        address_type
+    ]
+    field_to_nullify = address_field_names[address_field_index_to_nullify]
+
+    existing_address = getattr(
+        profile_with_verified_personal_information.verified_personal_information,
         address_type,
-        address_field_index_to_nullify,
-        user_gql_client,
-    ):
-        address_field_names = self.ADDRESS_FIELD_NAMES[address_type]
-        field_to_nullify = address_field_names[address_field_index_to_nullify]
-
-        existing_address = getattr(
-            profile_with_verified_personal_information.verified_personal_information,
-            address_type,
-        )
-
-        user_id = profile_with_verified_personal_information.user.uuid
-
-        address_data = {to_graphql_name(field_to_nullify): None}
-
-        input_data = {
-            "userId": str(user_id),
-            "profile": {
-                "verifiedPersonalInformation": {
-                    to_graphql_name(address_type): address_data
-                },
-            },
-        }
-
-        profile = self.execute_successful_mutation(input_data, user_gql_client)
-
-        address = getattr(profile.verified_personal_information, address_type)
-
-        for field_name in address_field_names:
-            if field_name == field_to_nullify:
-                assert getattr(address, field_name) == ""
-            else:
-                assert getattr(address, field_name) == getattr(
-                    existing_address, field_name
-                )
-
-    @pytest.mark.parametrize(
-        "address_type", ProfileWithVerifiedPersonalInformationTestBase.ADDRESS_TYPES,
     )
-    def test_do_not_touch_an_address_if_it_is_not_included_in_the_mutation(
-        self, profile_with_verified_personal_information, address_type, user_gql_client,
-    ):
-        existing_address = getattr(
-            profile_with_verified_personal_information.verified_personal_information,
-            address_type,
-        )
 
-        user_id = profile_with_verified_personal_information.user.uuid
+    user_id = profile_with_verified_personal_information.user.uuid
 
-        input_data = {
-            "userId": str(user_id),
-            "profile": {"verifiedPersonalInformation": {}},
-        }
+    address_data = {to_graphql_name(field_to_nullify): None}
 
-        profile = self.execute_successful_mutation(input_data, user_gql_client)
+    input_data = {
+        "userId": str(user_id),
+        "profile": {
+            "verifiedPersonalInformation": {
+                to_graphql_name(address_type): address_data
+            },
+        },
+    }
 
-        verified_personal_information = profile.verified_personal_information
-        address = getattr(verified_personal_information, address_type)
+    profile = execute_successful_mutation(input_data, user_gql_client)
 
-        for field_name in self.ADDRESS_FIELD_NAMES[address_type]:
+    address = getattr(profile.verified_personal_information, address_type)
+
+    for field_name in address_field_names:
+        if field_name == field_to_nullify:
+            assert getattr(address, field_name) == ""
+        else:
             assert getattr(address, field_name) == getattr(existing_address, field_name)
 
-    @pytest.mark.parametrize(
-        "address_type", ProfileWithVerifiedPersonalInformationTestBase.ADDRESS_TYPES,
+
+@pytest.mark.parametrize(
+    "address_type", VERIFIED_PERSONAL_INFORMATION_ADDRESS_TYPES,
+)
+def test_do_not_touch_an_address_if_it_is_not_included_in_the_mutation(
+    profile_with_verified_personal_information, address_type, user_gql_client,
+):
+    existing_address = getattr(
+        profile_with_verified_personal_information.verified_personal_information,
+        address_type,
     )
-    def test_delete_an_address_if_it_no_longer_has_any_data(
-        self, profile_with_verified_personal_information, address_type, user_gql_client,
-    ):
-        user_id = profile_with_verified_personal_information.user.uuid
 
-        address_fields = {}
-        for name in self.ADDRESS_FIELD_NAMES[address_type]:
-            address_fields[to_graphql_name(name)] = ""
+    user_id = profile_with_verified_personal_information.user.uuid
 
-        input_data = {
-            "userId": str(user_id),
-            "profile": {
-                "verifiedPersonalInformation": {
-                    to_graphql_name(address_type): address_fields
-                },
+    input_data = {
+        "userId": str(user_id),
+        "profile": {"verifiedPersonalInformation": {}},
+    }
+
+    profile = execute_successful_mutation(input_data, user_gql_client)
+
+    verified_personal_information = profile.verified_personal_information
+    address = getattr(verified_personal_information, address_type)
+
+    for field_name in VERIFIED_PERSONAL_INFORMATION_ADDRESS_FIELD_NAMES[address_type]:
+        assert getattr(address, field_name) == getattr(existing_address, field_name)
+
+
+@pytest.mark.parametrize(
+    "address_type", VERIFIED_PERSONAL_INFORMATION_ADDRESS_TYPES,
+)
+def test_delete_an_address_if_it_no_longer_has_any_data(
+    profile_with_verified_personal_information, address_type, user_gql_client,
+):
+    user_id = profile_with_verified_personal_information.user.uuid
+
+    address_fields = {}
+    for name in VERIFIED_PERSONAL_INFORMATION_ADDRESS_FIELD_NAMES[address_type]:
+        address_fields[to_graphql_name(name)] = ""
+
+    input_data = {
+        "userId": str(user_id),
+        "profile": {
+            "verifiedPersonalInformation": {
+                to_graphql_name(address_type): address_fields
             },
-        }
+        },
+    }
 
-        profile = TestProfileWithVerifiedPersonalInformationCreation.execute_successful_mutation(
-            input_data, user_gql_client
-        )
+    profile = execute_successful_mutation(input_data, user_gql_client)
 
-        assert not hasattr(profile.verified_personal_information, address_type)
+    assert not hasattr(profile.verified_personal_information, address_type)
 
-    @staticmethod
-    def service_input_data(user_id, service_client_id):
-        user_id = str(user_id)
-        return {
-            "userId": user_id,
-            "serviceClientId": service_client_id,
-            "profile": {"verifiedPersonalInformation": {"firstName": "John"}},
-        }
 
-    @staticmethod
-    def execute_service_connection_test(
-        user_id, service_in_mutation, expected_service_connections, gql_client
-    ):
-        input_data = TestProfileWithVerifiedPersonalInformationCreation.service_input_data(
-            user_id, service_in_mutation.client_ids.first().client_id
-        )
+def service_input_data(user_id, service_client_id):
+    user_id = str(user_id)
+    return {
+        "userId": user_id,
+        "serviceClientId": service_client_id,
+        "profile": {"verifiedPersonalInformation": {"firstName": "John"}},
+    }
 
-        profile = TestProfileWithVerifiedPersonalInformationCreation.execute_successful_mutation(
-            input_data, gql_client
-        )
 
-        connected_services = profile.service_connections.all()
+def execute_service_connection_test(
+    user_id, service_in_mutation, expected_service_connections, gql_client
+):
+    input_data = service_input_data(
+        user_id, service_in_mutation.client_ids.first().client_id
+    )
 
-        assert connected_services.count() == len(expected_service_connections)
-        for service in expected_service_connections:
-            connection = connected_services.get(service=service)
-            assert connection.service == service
-            assert connection.enabled
+    profile = execute_successful_mutation(input_data, gql_client)
 
-    def test_giving_non_existing_service_client_id_results_in_object_does_not_exist_error(
-        self, user_gql_client
-    ):
-        input_data = self.service_input_data(uuid.uuid1(), "not_existing")
+    connected_services = profile.service_connections.all()
 
-        executed = self.execute_mutation(input_data, user_gql_client)
+    assert connected_services.count() == len(expected_service_connections)
+    for service in expected_service_connections:
+        connection = connected_services.get(service=service)
+        assert connection.service == service
+        assert connection.enabled
 
-        assert_match_error_code(executed, "OBJECT_DOES_NOT_EXIST_ERROR")
 
-    def test_add_new_service_connections(
-        self, service_factory, service_client_id_factory, user_gql_client
-    ):
-        user_id = uuid.uuid1()
-        service1 = service_factory(service_type=ServiceType.BERTH)
-        service2 = service_factory(service_type=ServiceType.YOUTH_MEMBERSHIP)
-        service_client_id_factory(service=service1)
-        service_client_id_factory(service=service2)
+def test_giving_non_existing_service_client_id_results_in_object_does_not_exist_error(
+    user_gql_client,
+):
+    input_data = service_input_data(uuid.uuid1(), "not_existing")
 
-        self.execute_service_connection_test(
-            user_id, service1, [service1], user_gql_client
-        )
+    executed = execute_mutation(input_data, user_gql_client)
 
-        self.execute_service_connection_test(
-            user_id, service2, [service1, service2], user_gql_client
-        )
+    assert_match_error_code(executed, "OBJECT_DOES_NOT_EXIST_ERROR")
 
-    def test_adding_existing_connection_again_does_nothing(
-        self,
-        profile,
-        service,
-        service_connection_factory,
-        service_client_id_factory,
-        user_gql_client,
-    ):
-        service_client_id_factory(service=service)
-        service_connection_factory(profile=profile, service=service, enabled=True)
 
-        self.execute_service_connection_test(
-            profile.user.uuid, service, [service], user_gql_client
-        )
+def test_add_new_service_connections(
+    service_factory, service_client_id_factory, user_gql_client
+):
+    user_id = uuid.uuid1()
+    service1 = service_factory(service_type=ServiceType.BERTH)
+    service2 = service_factory(service_type=ServiceType.YOUTH_MEMBERSHIP)
+    service_client_id_factory(service=service1)
+    service_client_id_factory(service=service2)
 
-    def test_enable_existing_disabled_service_connection(
-        self,
-        profile,
-        service,
-        service_connection_factory,
-        service_client_id_factory,
-        user_gql_client,
-    ):
-        service_client_id_factory(service=service)
-        service_connection_factory(profile=profile, service=service, enabled=False)
+    execute_service_connection_test(user_id, service1, [service1], user_gql_client)
 
-        self.execute_service_connection_test(
-            profile.user.uuid, service, [service], user_gql_client
-        )
+    execute_service_connection_test(
+        user_id, service2, [service1, service2], user_gql_client
+    )
 
-    @staticmethod
-    def execute_mutation_with_invalid_input(gql_client):
-        input_data = {
-            "userId": "03117666-117D-4F6B-80B1-A3A92B389711",
-            "profile": {
-                "verifiedPersonalInformation": {
-                    "permanentForeignAddress": {"countryCode": "France"}
-                }
-            },
-        }
 
-        return TestProfileWithVerifiedPersonalInformationCreation.execute_mutation(
-            input_data, gql_client
-        )
+def test_adding_existing_connection_again_does_nothing(
+    profile,
+    service,
+    service_connection_factory,
+    service_client_id_factory,
+    user_gql_client,
+):
+    service_client_id_factory(service=service)
+    service_connection_factory(profile=profile, service=service, enabled=True)
 
-    def test_invalid_input_causes_a_validation_error(self, user_gql_client):
-        executed = self.execute_mutation_with_invalid_input(user_gql_client)
-        assert executed["errors"][0]["extensions"]["code"] == "VALIDATION_ERROR"
+    execute_service_connection_test(
+        profile.user.uuid, service, [service], user_gql_client
+    )
 
-    @pytest.mark.django_db(transaction=True)
-    def test_database_stays_unmodified_when_mutation_is_not_completed(
-        self, user_gql_client
-    ):
-        self.execute_mutation_with_invalid_input(user_gql_client)
 
-        assert Profile.objects.count() == 0
-        assert VerifiedPersonalInformation.objects.count() == 0
-        assert VerifiedPersonalInformationPermanentAddress.objects.count() == 0
-        assert VerifiedPersonalInformationTemporaryAddress.objects.count() == 0
-        assert VerifiedPersonalInformationPermanentForeignAddress.objects.count() == 0
+def test_enable_existing_disabled_service_connection(
+    profile,
+    service,
+    service_connection_factory,
+    service_client_id_factory,
+    user_gql_client,
+):
+    service_client_id_factory(service=service)
+    service_connection_factory(profile=profile, service=service, enabled=False)
+
+    execute_service_connection_test(
+        profile.user.uuid, service, [service], user_gql_client
+    )
+
+
+def execute_mutation_with_invalid_input(gql_client):
+    input_data = {
+        "userId": "03117666-117D-4F6B-80B1-A3A92B389711",
+        "profile": {
+            "verifiedPersonalInformation": {
+                "permanentForeignAddress": {"countryCode": "France"}
+            }
+        },
+    }
+
+    return execute_mutation(input_data, gql_client)
+
+
+def test_invalid_input_causes_a_validation_error(user_gql_client):
+    executed = execute_mutation_with_invalid_input(user_gql_client)
+    assert executed["errors"][0]["extensions"]["code"] == "VALIDATION_ERROR"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_database_stays_unmodified_when_mutation_is_not_completed(user_gql_client):
+    execute_mutation_with_invalid_input(user_gql_client)
+
+    assert Profile.objects.count() == 0
+    assert VerifiedPersonalInformation.objects.count() == 0
+    assert VerifiedPersonalInformationPermanentAddress.objects.count() == 0
+    assert VerifiedPersonalInformationTemporaryAddress.objects.count() == 0
+    assert VerifiedPersonalInformationPermanentForeignAddress.objects.count() == 0

--- a/profiles/tests/test_gql_my_profile_query.py
+++ b/profiles/tests/test_gql_my_profile_query.py
@@ -8,7 +8,7 @@ from subscriptions.tests.factories import (
     SubscriptionTypeFactory,
 )
 
-from .conftest import ProfileWithVerifiedPersonalInformationTestBase
+from .conftest import VERIFIED_PERSONAL_INFORMATION_ADDRESS_TYPES
 from .factories import (
     AddressFactory,
     EmailFactory,
@@ -187,9 +187,7 @@ def test_normal_user_can_query_primary_contact_details(user_gql_client):
     assert dict(executed["data"]) == expected_data
 
 
-class TestProfileWithVerifiedPersonalInformation(
-    ProfileWithVerifiedPersonalInformationTestBase
-):
+class TestProfileWithVerifiedPersonalInformation:
     QUERY = """
         {
             myProfile {
@@ -288,7 +286,7 @@ class TestProfileWithVerifiedPersonalInformation(
         assert executed["data"] == expected_data
 
     @pytest.mark.parametrize(
-        "address_type", ProfileWithVerifiedPersonalInformationTestBase.ADDRESS_TYPES,
+        "address_type", VERIFIED_PERSONAL_INFORMATION_ADDRESS_TYPES,
     )
     def test_when_address_does_not_exist_returns_null(
         self, address_type, user_gql_client
@@ -303,7 +301,7 @@ class TestProfileWithVerifiedPersonalInformation(
         assert "errors" not in executed
 
         received_info = executed["data"]["myProfile"]["verifiedPersonalInformation"]
-        for at in self.ADDRESS_TYPES:
+        for at in VERIFIED_PERSONAL_INFORMATION_ADDRESS_TYPES:
             received_address = received_info[to_graphql_name(at)]
             if at == address_type:
                 assert received_address is None


### PR DESCRIPTION
It's now possible to create/update the primary email of a profile with the `createOrUpdateProfileWithVerifiedPersonalInformation` mutation.