### PR TITLE
Add one more permission to test setup

### DIFF
--- a/profiles/tests/test_gql_create_profile_mutation.py
+++ b/profiles/tests/test_gql_create_profile_mutation.py
@@ -258,6 +258,7 @@ def test_staff_user_cannot_create_a_profile_with_sensitive_data_without_sensitiv
     user.groups.add(group_berth)
     user.groups.add(group_youth)
     assign_perm("can_manage_profiles", group_berth, service_berth)
+    assign_perm("can_manage_profiles", group_youth, service_youth)
     assign_perm("can_manage_sensitivedata", group_youth, service_youth)
     assign_perm("can_view_sensitivedata", group_youth, service_youth)
 


### PR DESCRIPTION
This test uses two Services, service_berth and service_youth. The idea
is that if the requester is coming from service_youth, then they have
all the required permissions to create a Profile with sensitive data. If
the requester is coming from servie_berth, then they can't, since in
that case they don't have the required sensitive data permissions (just
the "can_manage_profiles" permission).

Since the request in this test is executed as coming from service_berth,
the request fails and that is the expected result. If the request would
be coming from service_youth, then it should succeed. But that wasn't
the case, without this one missing permission.