### PR TITLE
Deactivate service type GraphQL arguments

### DIFF
--- a/open_city_profile/graphene.py
+++ b/open_city_profile/graphene.py
@@ -13,7 +13,6 @@ from profiles.loaders import (
     PrimaryEmailForProfileLoader,
     PrimaryPhoneForProfileLoader,
 )
-from profiles.utils import set_current_service
 
 
 class JWTMiddleware:
@@ -76,8 +75,5 @@ class GQLDataLoaders:
 def determine_service_middleware(next, root, info, **kwargs):
     if not hasattr(info.context, "service"):
         info.context.service = None
-
-    if info.context.service:
-        set_current_service(info.context.service)
 
     return next(root, info, **kwargs)

--- a/open_city_profile/graphene.py
+++ b/open_city_profile/graphene.py
@@ -14,7 +14,6 @@ from profiles.loaders import (
     PrimaryPhoneForProfileLoader,
 )
 from profiles.utils import set_current_service
-from services.models import Service
 
 
 class JWTMiddleware:
@@ -75,46 +74,10 @@ class GQLDataLoaders:
 
 
 def determine_service_middleware(next, root, info, **kwargs):
-    """Determine service from the context or from a service type argument
-
-    The service read from an argument is only enabled for the duration of the resolve
-    and the original service is restored after the resolve has run. (Reading from an
-    argument is only for backwards compatibility and should be removed after the
-    "service_type" fields are removed)"""
     if not hasattr(info.context, "service"):
         info.context.service = None
-
-    # Determine service_type from the arguments
-    service_type = None
-    if "input" in kwargs:
-        input_argument = kwargs.get("input", {})
-        # Most of the mutations
-        if "service_type" in input_argument:
-            service_type = input_argument.get("service_type")
-        # AddServiceConnectionMutation
-        elif "service_connection" in input_argument:
-            service_type = (
-                input_argument.get("service_connection", {})
-                .get("service", {})
-                .get("type")
-            )
-    else:
-        # Queries
-        service_type = kwargs.get("service_type")
-
-    old_service = None
-    if service_type:
-        old_service = getattr(info.context, "service", None)
-        info.context.service = Service.objects.get(service_type=service_type)
 
     if info.context.service:
         set_current_service(info.context.service)
 
-    try:
-        return_value = next(root, info, **kwargs)
-    finally:
-        if old_service:
-            info.context.service = old_service
-            set_current_service(old_service)
-
-    return return_value
+    return next(root, info, **kwargs)

--- a/open_city_profile/graphene.py
+++ b/open_city_profile/graphene.py
@@ -70,10 +70,3 @@ class GQLDataLoaders:
             self.cached_loaders = True
 
         return next(root, info, **kwargs)
-
-
-def determine_service_middleware(next, root, info, **kwargs):
-    if not hasattr(info.context, "service"):
-        info.context.service = None
-
-    return next(root, info, **kwargs)

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -292,11 +292,7 @@ MAILER_EMAIL_BACKEND = env.str("MAILER_EMAIL_BACKEND")
 GRAPHENE = {
     "SCHEMA": "open_city_profile.schema.schema",
     "MIDDLEWARE": [
-        # JSONWebTokenMiddleware must run before determine_service_middleware
-        # so that JSONWebTokenMiddleware will set the service in the context
-        # before the determine_service_middleware is run. determine_service_middleware
-        # is defined here first because the Middleware are run in reverse order.
-        "open_city_profile.graphene.determine_service_middleware",
+        # NOTE: Graphene runs its middlewares in reverse order!
         "open_city_profile.graphene.JWTMiddleware"
         if USE_HELUSERS_REQUEST_JWT_AUTH
         else "graphql_jwt.middleware.JSONWebTokenMiddleware",

--- a/open_city_profile/tests/conftest.py
+++ b/open_city_profile/tests/conftest.py
@@ -55,6 +55,9 @@ class GraphQLClient(GrapheneClient):
                 context.user, auth_token_payload or {}
             )
 
+        if not hasattr(context, "service"):
+            context.service = None
+
         if service is _not_provided:
             context.service = ServiceFactory(
                 service_type=None, implicit_connection=True,

--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -394,7 +394,7 @@ type ServiceNode implements Node {
   gdprQueryScope: String!
   gdprDeleteScope: String!
   serviceconnectionSet(before: String, after: String, first: Int, last: Int): ServiceConnectionTypeConnection!
-  type: ServiceType
+  type: ServiceType @deprecated(reason: "See \'name\' field for a replacement.")
   title: String
   description: String
 }
@@ -410,10 +410,10 @@ type ServiceNodeEdge {
 }
 
 enum ServiceType {
-  HKI_MY_DATA
-  BERTH
-  YOUTH_MEMBERSHIP
-  GODCHILDREN_OF_CULTURE
+  HKI_MY_DATA @deprecated(reason: "The whole ServiceType enum is deprecated and shouldn\'t be used anymore. There are different replacements in various places, depending on how this type was used.")
+  BERTH @deprecated(reason: "The whole ServiceType enum is deprecated and shouldn\'t be used anymore. There are different replacements in various places, depending on how this type was used.")
+  YOUTH_MEMBERSHIP @deprecated(reason: "The whole ServiceType enum is deprecated and shouldn\'t be used anymore. There are different replacements in various places, depending on how this type was used.")
+  GODCHILDREN_OF_CULTURE @deprecated(reason: "The whole ServiceType enum is deprecated and shouldn\'t be used anymore. There are different replacements in various places, depending on how this type was used.")
 }
 
 input SubscriptionInputType {

--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -387,6 +387,7 @@ input ServiceInput {
 
 type ServiceNode implements Node {
   id: ID!
+  name: String!
   allowedDataFields(before: String, after: String, first: Int, last: Int): AllowedDataFieldNodeConnection!
   createdAt: DateTime!
   gdprUrl: String!

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -730,8 +730,7 @@ class CreateProfileMutation(relay.ClientIDMutation):
     class Input:
         service_type = graphene.Argument(
             AllowedServiceType,
-            description="**DEPRECATED**: requester's service is determined by authentication, "
-            "but for now it can still be overridden by this argument.",
+            description="**OBSOLETE**: doesn't do anything. Requester's service is determined by authentication.",
         )
         profile = CreateProfileInput(required=True)
 
@@ -1023,8 +1022,7 @@ class UpdateProfileMutation(relay.ClientIDMutation):
     class Input:
         service_type = graphene.Argument(
             AllowedServiceType,
-            description="**DEPRECATED**: requester's service is determined by authentication, "
-            "but for now it can still be overridden by this argument.",
+            description="**OBSOLETE**: doesn't do anything. Requester's service is determined by authentication.",
         )
         profile = UpdateProfileInput(required=True)
 
@@ -1199,8 +1197,7 @@ class Query(graphene.ObjectType):
         id=graphene.Argument(graphene.ID, required=True),
         service_type=graphene.Argument(
             AllowedServiceType,
-            description="**DEPRECATED**: requester's service is determined by authentication, "
-            "but for now it can still be overridden by this argument.",
+            description="**OBSOLETE**: doesn't do anything. Requester's service is determined by authentication.",
         ),
         description="Get profile by profile ID.\n\nRequires `staff` credentials for the requester's service."
         "The profile must have an active connection to the requester's service, otherwise "
@@ -1230,8 +1227,7 @@ class Query(graphene.ObjectType):
         ProfileNode,
         service_type=graphene.Argument(
             AllowedServiceType,
-            description="**DEPRECATED**: requester's service is determined by authentication, "
-            "but for now it can still be overridden by this argument.",
+            description="**OBSOLETE**: doesn't do anything. Requester's service is determined by authentication.",
         ),
         description="Search for profiles. The results are filtered based on the given parameters. The results are "
         "paged using Relay.\n\nRequires `staff` credentials for the requester's service."

--- a/profiles/tests/test_gql_create_profile_mutation.py
+++ b/profiles/tests/test_gql_create_profile_mutation.py
@@ -63,6 +63,7 @@ ${email_input}
                             node {
                                 service {
                                     type
+                                    name
                                 }
                             }
                         }
@@ -119,7 +120,16 @@ ${email_input}
                     else []
                 },
                 "serviceConnections": {
-                    "edges": [{"node": {"service": {"type": ServiceType.BERTH.name}}}]
+                    "edges": [
+                        {
+                            "node": {
+                                "service": {
+                                    "type": service.service_type.name,
+                                    "name": service.name,
+                                }
+                            }
+                        }
+                    ]
                 },
             }
         }

--- a/profiles/tests/test_gql_profile_query.py
+++ b/profiles/tests/test_gql_profile_query.py
@@ -46,10 +46,11 @@ def test_staff_user_can_query_a_profile_connected_to_service_he_is_admin_of(
     user.groups.add(group)
     assign_perm("can_view_profiles", group, service)
 
+    # serviceType is included in query just to ensure that it has NO affect
     t = Template(
         """
         {
-            profile(id: "${id}") {
+            profile(id: "${id}", serviceType: GODCHILDREN_OF_CULTURE) {
                 firstName
                 lastName
             }
@@ -116,38 +117,6 @@ def test_staff_user_cannot_query_a_profile_without_a_connection_to_their_service
     assert "errors" in executed
     assert "code" in executed["errors"][0]["extensions"]
     assert executed["errors"][0]["extensions"]["code"] == OBJECT_DOES_NOT_EXIST_ERROR
-
-
-def test_staff_user_cannot_override_service_with_argument_they_are_not_an_admin_of(
-    user_gql_client, profile, group, service_factory
-):
-    service_berth = service_factory()
-    service_youth = service_factory(service_type=ServiceType.YOUTH_MEMBERSHIP)
-    ServiceConnectionFactory(profile=profile, service=service_berth)
-    user = user_gql_client.user
-    user.groups.add(group)
-    assign_perm("can_view_profiles", group, service_youth)
-
-    t = Template(
-        """
-        {
-            profile(id: "${id}", serviceType: ${service_type}) {
-                firstName
-                lastName
-            }
-        }
-    """
-    )
-
-    query = t.substitute(
-        id=relay.Node.to_global_id(ProfileNode._meta.name, profile.id),
-        service_type=ServiceType.BERTH.name,
-    )
-    executed = user_gql_client.execute(query, service=service_youth)
-    assert "errors" in executed
-    assert executed["errors"][0]["message"] == _(
-        "You do not have permission to perform this action."
-    )
 
 
 def test_staff_user_cannot_query_sensitive_data_with_only_profile_permissions(

--- a/profiles/tests/test_gql_profiles_query.py
+++ b/profiles/tests/test_gql_profiles_query.py
@@ -87,9 +87,10 @@ def test_staff_user_with_group_access_can_query_profiles(
     user.groups.add(group)
     assign_perm("can_view_profiles", group, service)
 
+    # serviceType is included in query just to ensure that it has NO affect
     query = """
         {
-            profiles {
+            profiles(serviceType: GODCHILDREN_OF_CULTURE) {
                 edges {
                     node {
                         firstName
@@ -851,47 +852,3 @@ def test_not_specifying_requesters_service_results_in_permission_denied_error(
     """
     executed = user_gql_client.execute(query)
     assert_match_error_code(executed, "PERMISSION_DENIED_ERROR")
-
-
-def test_service_type_argument_temporarily_overrides_the_requesters_service(
-    user_gql_client, group, service_factory
-):
-    profile_berth = ProfileFactory()
-    profile_youth = ProfileFactory()
-    service_berth = service_factory(service_type=ServiceType.BERTH)
-    service_youth = service_factory(service_type=ServiceType.YOUTH_MEMBERSHIP)
-    ServiceConnectionFactory(profile=profile_berth, service=service_berth)
-    ServiceConnectionFactory(profile=profile_youth, service=service_youth)
-    user = user_gql_client.user
-    user.groups.add(group)
-    assign_perm("can_view_profiles", group, service_berth)
-    assign_perm("can_view_profiles", group, service_youth)
-
-    t = Template(
-        """
-        {
-            berthProfiles: profiles(serviceType: ${service_type}) {
-                edges {
-                    node {
-                        firstName
-                    }
-                }
-            }
-
-            youthProfiles: profiles {
-                edges {
-                    node {
-                        firstName
-                    }
-                }
-            }
-        }
-    """
-    )
-    query = t.substitute(service_type=ServiceType.BERTH.name)
-    expected_data = {
-        "berthProfiles": {"edges": [{"node": {"firstName": profile_berth.first_name}}]},
-        "youthProfiles": {"edges": [{"node": {"firstName": profile_youth.first_name}}]},
-    }
-    executed = user_gql_client.execute(query, service=service_youth)
-    assert executed["data"] == expected_data

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -55,17 +55,17 @@ def clear_thread_locals():
     _thread_locals.__dict__.clear()
 
 
-def set_current_service(service):
-    _thread_locals.service = service
-
-
 def get_current_request():
     return getattr(_thread_locals, "request", None)
 
 
-def get_current_user():
+def _get_current_request_attr(attrname):
     request = get_current_request()
-    return getattr(request, "user", None) if request else None
+    return getattr(request, attrname, None) if request else None
+
+
+def get_current_user():
+    return _get_current_request_attr("user")
 
 
 def get_original_client_ip():
@@ -84,7 +84,7 @@ def get_original_client_ip():
 
 
 def get_current_service():
-    return getattr(_thread_locals, "service", None)
+    return _get_current_request_attr("service")
 
 
 def requester_has_service_permission(request, permission):

--- a/services/schema.py
+++ b/services/schema.py
@@ -11,7 +11,10 @@ from .enums import ServiceType
 from .models import AllowedDataField, Service, ServiceConnection
 
 AllowedServiceType = graphene.Enum.from_enum(
-    ServiceType, description=lambda e: e.label if e else ""
+    ServiceType,
+    description=lambda e: e.label if e else "",
+    deprecation_reason=lambda e: "The whole ServiceType enum is deprecated and shouldn't be used anymore. "
+    "There are different replacements in various places, depending on how this type was used.",
 )
 
 
@@ -24,7 +27,9 @@ class AllowedDataFieldNode(DjangoObjectType):
 
 
 class ServiceNode(DjangoObjectType):
-    type = AllowedServiceType(source="service_type")
+    type = AllowedServiceType(
+        source="service_type", deprecation_reason="See 'name' field for a replacement.",
+    )
     title = graphene.String()
     description = graphene.String()
 

--- a/services/schema.py
+++ b/services/schema.py
@@ -57,8 +57,7 @@ class ServiceInput(graphene.InputObjectType):
 
 class ServiceConnectionInput(graphene.InputObjectType):
     service = ServiceInput(
-        description="**DEPRECATED**: requester's service is determined by authentication, "
-        "but for now it can still be overridden by this argument."
+        description="**OBSOLETE**: doesn't do anything. Requester's service is determined by authentication."
     )
     enabled = graphene.Boolean()
 

--- a/services/schema.py
+++ b/services/schema.py
@@ -32,6 +32,7 @@ class ServiceNode(DjangoObjectType):
         model = Service
         fields = (
             "id",
+            "name",
             "allowed_data_fields",
             "created_at",
             "gdpr_url",

--- a/services/tests/test_services_graphql_api.py
+++ b/services/tests/test_services_graphql_api.py
@@ -3,7 +3,6 @@ from open_city_profile.consts import (
     SERVICE_NOT_IDENTIFIED_ERROR,
 )
 from open_city_profile.tests.asserts import assert_match_error_code
-from services.enums import ServiceType
 from services.tests.factories import ProfileFactory, ServiceConnectionFactory
 
 
@@ -26,6 +25,7 @@ def test_normal_user_can_query_own_services(
                         node {
                             service {
                                 type
+                                name
                                 title
                                 description
                                 allowedDataFields {
@@ -50,7 +50,8 @@ def test_normal_user_can_query_own_services(
                     {
                         "node": {
                             "service": {
-                                "type": ServiceType.BERTH.name,
+                                "type": service.service_type.name,
+                                "name": service.name,
                                 "title": service.title,
                                 "description": service.description,
                                 "allowedDataFields": {
@@ -97,6 +98,7 @@ def test_normal_user_can_add_service(user_gql_client, service):
                 serviceConnection {
                     service {
                         type
+                        name
                     }
                     enabled
                 }
@@ -107,7 +109,7 @@ def test_normal_user_can_add_service(user_gql_client, service):
     expected_data = {
         "addServiceConnection": {
             "serviceConnection": {
-                "service": {"type": service.service_type.name},
+                "service": {"type": service.service_type.name, "name": service.name},
                 "enabled": False,
             }
         }
@@ -130,6 +132,7 @@ def test_normal_user_cannot_add_service_multiple_times_mutation(
                 serviceConnection {
                     service {
                         type
+                        name
                     }
                 }
             }
@@ -138,7 +141,9 @@ def test_normal_user_cannot_add_service_multiple_times_mutation(
 
     expected_data = {
         "addServiceConnection": {
-            "serviceConnection": {"service": {"type": ServiceType.BERTH.name}}
+            "serviceConnection": {
+                "service": {"type": service.service_type.name, "name": service.name}
+            }
         }
     }
     executed = user_gql_client.execute(query, service=service)
@@ -169,6 +174,7 @@ def test_not_identifying_service_for_add_service_connection_produces_service_not
                 serviceConnection {
                     service {
                         type
+                        name
                     }
                 }
             }
@@ -200,6 +206,7 @@ def test_normal_user_can_query_own_services_gdpr_api_scopes(
                         node {
                             service {
                                 type
+                                name
                                 gdprQueryScope
                                 gdprDeleteScope
                             }
@@ -218,6 +225,7 @@ def test_normal_user_can_query_own_services_gdpr_api_scopes(
                         "node": {
                             "service": {
                                 "type": service.service_type.name,
+                                "name": service.name,
                                 "gdprQueryScope": query_scope,
                                 "gdprDeleteScope": delete_scope,
                             }

--- a/services/tests/test_utils.py
+++ b/services/tests/test_utils.py
@@ -20,7 +20,8 @@ def test_service_can_not_be_determined(req, user_auth):
     if user_auth:
         req.user_auth = user_auth
     set_service_to_request(req)
-    assert not hasattr(req, "service")
+
+    assert req.service is None
     assert not hasattr(req, "service_client_id")
 
 

--- a/services/utils.py
+++ b/services/utils.py
@@ -2,7 +2,10 @@ from services.models import ServiceClientId
 
 
 def set_service_to_request(request):
-    if not hasattr(request, "service") and hasattr(request, "user_auth"):
+    if not hasattr(request, "service"):
+        request.service = None
+
+    if request.service is None and hasattr(request, "user_auth"):
         client_id = request.user_auth.data.get("azp")
         if not client_id:
             return


### PR DESCRIPTION
The `serviceType` arguments in some GraphQL calls were deprecated earlier, but left still functioning. Since “azp” JWT claims can now be used for service determination everywhere, it’s time to make the `serviceType` arguments non-functional.