### PR TITLE
Add client id to audit log

### DIFF
--- a/profiles/audit_log.py
+++ b/profiles/audit_log.py
@@ -5,7 +5,12 @@ from datetime import datetime, timezone
 from django.conf import settings
 from django.utils.text import camel_case_to_spaces
 
-from .utils import get_current_service, get_current_user, get_original_client_ip
+from .utils import (
+    get_current_client_id,
+    get_current_service,
+    get_current_user,
+    get_original_client_ip,
+)
 
 
 def should_audit(model):
@@ -76,6 +81,9 @@ def log(action, instance):
         service = get_current_service()
         if service:
             message["audit_event"]["actor"]["service_name"] = service.name
+        client_id = get_current_client_id()
+        if client_id:
+            message["audit_event"]["actor"]["client_id"] = client_id
 
         ip_address = get_original_client_ip()
         if ip_address:

--- a/profiles/tests/test_audit_log.py
+++ b/profiles/tests/test_audit_log.py
@@ -304,6 +304,8 @@ def test_service_is_resolved_in_graphql_call(
     actor_log = log_message["audit_event"]["actor"]
     assert "service_name" in actor_log
     assert actor_log["service_name"] == service.name
+    assert "client_id" in actor_log
+    assert actor_log["client_id"] == service_client_id.client_id
 
 
 def test_actor_service(live_server, user, group, service_client_id, cap_audit_log):
@@ -336,6 +338,8 @@ def test_actor_service(live_server, user, group, service_client_id, cap_audit_lo
     assert_common_fields(log_message, profile, "READ", actor_role="ADMIN")
     actor_log = log_message["audit_event"]["actor"]
     assert actor_log["service_name"] == service.name
+    assert "client_id" in actor_log
+    assert actor_log["client_id"] == service_client_id.client_id
 
 
 class TestIPAddressLogging:

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -87,6 +87,10 @@ def get_current_service():
     return _get_current_request_attr("service")
 
 
+def get_current_client_id():
+    return _get_current_request_attr("client_id")
+
+
 def requester_has_service_permission(request, permission):
     service = getattr(request, "service", None)
 

--- a/services/tests/test_utils.py
+++ b/services/tests/test_utils.py
@@ -28,8 +28,10 @@ def test_service_can_not_be_determined(req, user_auth):
 def test_when_client_id_is_found_then_service_is_added_to_request(
     req, service_client_id
 ):
-    req.user_auth = UserAuth({"azp": service_client_id.client_id})
+    client_id = service_client_id.client_id
+
+    req.user_auth = UserAuth({"azp": client_id})
     set_service_to_request(req)
 
-    assert req.service_client_id == service_client_id
+    assert req.client_id == client_id
     assert req.service == service_client_id.service

--- a/services/utils.py
+++ b/services/utils.py
@@ -18,5 +18,5 @@ def set_service_to_request(request):
         if not service_client_id:
             return
 
-        request.service_client_id = service_client_id
+        request.client_id = service_client_id.client_id
         request.service = service_client_id.service


### PR DESCRIPTION
The client id is received from the HTTP request's authentication JWT, from its "azp" claim. That value (if present) is now added to the audit log lines.