### PR TITLE
Cleaning up service types part 1 (of 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,10 @@ Prerequisites:
 5. Set permissions for service staff members if needed:
    * Create group(s) (via Django admin) and add user(s) to the group
    * Create service permissions for group manually via Django admin or for example:
-     * `docker exec profile-backend python manage.py add_object_permission BERTH
-     VeneAdmin can_view_profiles`
-     * where:
-       * `service_type=BERTH`
-       * `group_name=VeneAdmin`
-       * `permission=can_view_profiles`
+     * `docker exec profile-backend python manage.py add_object_permission ServiceName GroupName can_view_profiles`,  where:
+       * `ServiceName` is the name of the Service the permission is given for
+       * `GroupName` is the name of the group to whom the permission is give
+       * `can_view_profiles` is the name of the permission
    * Permissions can be removed as follows:
      * `docker exec profile-backend python manage.py remove_object_permission BERTH
      VeneAdmin can_view_profiles`

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Prerequisites:
     * Command will generate:
       * All available services
       * One group per service (with `can_manage_profiles` permissions)
-      * One user per group (with username `{service_type}_user`)
+      * One user per group (with username `{group.name}_user`)
       * Profiles
         * With user
         * With email, phone number and address

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ Prerequisites:
        * `GroupName` is the name of the group to whom the permission is give
        * `can_view_profiles` is the name of the permission
    * Permissions can be removed as follows:
-     * `docker exec profile-backend python manage.py remove_object_permission BERTH
-     VeneAdmin can_view_profiles`
+     * `docker exec profile-backend python manage.py remove_object_permission ServiceName GroupName can_view_profiles`
 
 6. Seed development data
     * **Note!** This command will flush the database.

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -3,7 +3,7 @@ from functools import reduce
 
 from django import forms
 from django.contrib import admin, messages
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.forms.models import ModelForm
 from django.http import JsonResponse
 from django.shortcuts import render
@@ -24,6 +24,7 @@ from profiles.models import (
     VerifiedPersonalInformation,
 )
 from services.admin import ServiceConnectionInline
+from services.models import Service
 from subscriptions.admin import SubscriptionInline
 
 
@@ -159,6 +160,12 @@ class VerifiedPersonalInformationAdminInline(admin.StackedInline):
 
 class ImportProfilesFromJsonForm(forms.Form):
     json_file = forms.FileField(required=True, label="Please select a json file")
+    service = forms.ModelChoiceField(
+        required=False,
+        queryset=Service.objects.all(),
+        to_field_name="name",
+        label="Connect imported profiles to service",
+    )
 
 
 @admin.register(Profile)
@@ -196,11 +203,17 @@ class ExtendedProfileAdmin(VersionAdmin):
     def upload_json(self, request):
         try:
             if request.method == "POST":
-                data = json.loads(request.FILES["json_file"].read())
-                result = Profile.import_customer_data(data)
-                response = JsonResponse(result)
-                response["Content-Disposition"] = "attachment; filename=export.json"
-                return response
+                form = ImportProfilesFromJsonForm(request.POST, request.FILES)
+                if form.is_valid():
+                    data = json.loads(request.FILES["json_file"].read())
+                    service = form.cleaned_data["service"]
+                    result = Profile.import_customer_data(data, service)
+                    response = JsonResponse(result)
+                    response["Content-Disposition"] = "attachment; filename=export.json"
+
+                    return response
+                else:
+                    raise ValidationError(form.errors.as_text())
             else:
                 form = ImportProfilesFromJsonForm()
                 return render(

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -14,8 +14,7 @@ from enumfields import EnumField
 from munigeo.models import AdministrativeDivision
 from thesaurus.models import Concept
 
-from services.enums import ServiceType
-from services.models import Service, ServiceConnection
+from services.models import ServiceConnection
 from users.models import User
 from utils.models import (
     NullsToEmptyStringsModel,
@@ -158,7 +157,7 @@ class Profile(UUIDModel, SerializableMixin):
 
     @classmethod
     @transaction.atomic
-    def import_customer_data(cls, data):
+    def import_customer_data(cls, data, service):
         """
         Imports list of customers of the following shape:
         {
@@ -209,11 +208,10 @@ class Profile(UUIDModel, SerializableMixin):
                     profile.phones.create(
                         phone=phone, phone_type=PhoneType.MOBILE, primary=index == 0
                     )
-                ServiceConnection.objects.create(
-                    profile=profile,
-                    service=Service.objects.get(service_type=ServiceType.BERTH),
-                    enabled=False,
-                )
+                if service:
+                    ServiceConnection.objects.create(
+                        profile=profile, service=service, enabled=False,
+                    )
                 result[item["customer_id"]] = profile.pk
             except Exception as err:
                 msg = (

--- a/profiles/tests/test_gql_create_profile_mutation.py
+++ b/profiles/tests/test_gql_create_profile_mutation.py
@@ -9,6 +9,7 @@ from services.enums import ServiceType
 
 
 @pytest.mark.parametrize("with_email", [True, False])
+@pytest.mark.parametrize("service__service_type", [ServiceType.BERTH])
 def test_staff_user_can_create_a_profile(
     user_gql_client, email_data, phone_data, address_data, group, service, with_email,
 ):

--- a/profiles/tests/test_gql_update_profile_mutation.py
+++ b/profiles/tests/test_gql_update_profile_mutation.py
@@ -16,7 +16,6 @@ from .factories import AddressFactory, PhoneFactory, ProfileWithPrimaryEmailFact
 
 @pytest.mark.parametrize("with_serviceconnection", (True, False))
 @pytest.mark.parametrize("implicit_serviceconnection", (True, False))
-@pytest.mark.parametrize("service__service_type", [ServiceType.YOUTH_MEMBERSHIP])
 def test_staff_user_can_update_a_profile(
     user_gql_client, group, service, with_serviceconnection, implicit_serviceconnection
 ):
@@ -142,7 +141,6 @@ def test_staff_user_can_update_a_profile(
         assert executed["data"]["updateProfile"] is None
 
 
-@pytest.mark.parametrize("service__service_type", [ServiceType.YOUTH_MEMBERSHIP])
 def test_staff_user_cannot_update_profile_sensitive_data_without_correct_permission(
     user_gql_client, group, service
 ):

--- a/profiles/tests/test_models.py
+++ b/profiles/tests/test_models.py
@@ -6,8 +6,6 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test import override_settings
 
-from services.enums import ServiceType
-
 from ..models import Email, Profile, TemporaryReadAccessToken
 from .factories import (
     EmailFactory,
@@ -117,15 +115,12 @@ def test_import_customer_data_with_valid_data_set(service):
         },
     ]
     assert Profile.objects.count() == 0
-    result = Profile.import_customer_data(data)
+    result = Profile.import_customer_data(data, service)
     assert len(result.keys()) == 2
     profiles = Profile.objects.all()
     assert len(profiles) == 2
     for profile in profiles:
-        assert (
-            profile.service_connections.first().service.service_type
-            == ServiceType.BERTH
-        )
+        assert profile.service_connections.first().service == service
 
 
 def test_import_customer_data_with_missing_customer_id():
@@ -154,12 +149,12 @@ def test_import_customer_data_with_missing_customer_id():
     ]
     assert Profile.objects.count() == 0
     with pytest.raises(Exception) as e:
-        Profile.import_customer_data(data)
+        Profile.import_customer_data(data, "")
     assert str(e.value) == "Could not import unknown customer, index: 0"
     assert Profile.objects.count() == 0
 
 
-def test_import_customer_data_with_missing_email(service):
+def test_import_customer_data_with_missing_email():
     data = [
         {
             "customer_id": "321457",
@@ -175,7 +170,7 @@ def test_import_customer_data_with_missing_email(service):
         }
     ]
     assert Profile.objects.count() == 0
-    Profile.import_customer_data(data)
+    Profile.import_customer_data(data, "")
     assert Profile.objects.count() == 1
 
 

--- a/services/management/commands/add_object_permission.py
+++ b/services/management/commands/add_object_permission.py
@@ -2,7 +2,6 @@ from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand
 from guardian.shortcuts import assign_perm
 
-from services.enums import ServiceType
 from services.models import Service
 
 available_permissions = [item[0] for item in Service._meta.permissions]
@@ -13,9 +12,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "service_type",
-            type=str,
-            help="Service type (must match service type in the model)",
+            "service", type=str, help="Service, identified by its name",
         )
         parser.add_argument(
             "group_name",
@@ -32,21 +29,21 @@ class Command(BaseCommand):
         try:
             if kwargs["permission"] not in available_permissions:
                 raise ValueError
-            service_type = kwargs["service_type"]
-            service = Service.objects.get(service_type=ServiceType[service_type].value)
+            service_name = kwargs["service"]
+            service = Service.objects.get(name=service_name)
             group = Group.objects.get(name=kwargs["group_name"])
             permission = kwargs["permission"]
             assign_perm(permission, group, service)
             self.stdout.write(
                 self.style.SUCCESS(
                     "Permission {} added for {} on service {}".format(
-                        permission, group, service.service_type
+                        permission, group, service.name
                     )
                 )
             )
 
         except Service.DoesNotExist:
-            self.stdout.write(self.style.ERROR("Invalid service_type given"))
+            self.stdout.write(self.style.ERROR("Invalid service given"))
         except Group.DoesNotExist:
             self.stdout.write(self.style.ERROR("Invalid group_name given"))
         except ValueError:

--- a/services/management/commands/object_permission_command.py
+++ b/services/management/commands/object_permission_command.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import Group
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from services.models import Service
 
@@ -36,8 +36,8 @@ class ObjectPermissionCommand(BaseCommand):
 
             self.do_handle(permission, group, service)
         except Service.DoesNotExist:
-            self.stdout.write(self.style.ERROR("Invalid service given"))
+            raise CommandError("Invalid service given")
         except Group.DoesNotExist:
-            self.stdout.write(self.style.ERROR("Invalid group_name given"))
+            raise CommandError("Invalid group_name given")
         except ValueError:
-            self.stdout.write(self.style.ERROR("Invalid permission given"))
+            raise CommandError("Invalid permission given")

--- a/services/management/commands/object_permission_command.py
+++ b/services/management/commands/object_permission_command.py
@@ -1,0 +1,43 @@
+from django.contrib.auth.models import Group
+from django.core.management.base import BaseCommand
+
+from services.models import Service
+
+available_permissions = [item[0] for item in Service._meta.permissions]
+
+
+class ObjectPermissionCommand(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "service", type=str, help="Service, identified by its name",
+        )
+        parser.add_argument(
+            "group_name",
+            type=str,
+            help="Group name (must match group name in the model)",
+        )
+        parser.add_argument(
+            "permission",
+            type=str,
+            help="Permission (options: {})".format(", ".join(available_permissions)),
+        )
+
+    def do_handle(self, permission, group, service):
+        raise NotImplementedError("Implement do_handle in the derived class")
+
+    def handle(self, *args, **kwargs):
+        try:
+            if kwargs["permission"] not in available_permissions:
+                raise ValueError
+            service_name = kwargs["service"]
+            service = Service.objects.get(name=service_name)
+            group = Group.objects.get(name=kwargs["group_name"])
+            permission = kwargs["permission"]
+
+            self.do_handle(permission, group, service)
+        except Service.DoesNotExist:
+            self.stdout.write(self.style.ERROR("Invalid service given"))
+        except Group.DoesNotExist:
+            self.stdout.write(self.style.ERROR("Invalid group_name given"))
+        except ValueError:
+            self.stdout.write(self.style.ERROR("Invalid permission given"))

--- a/services/management/commands/remove_object_permission.py
+++ b/services/management/commands/remove_object_permission.py
@@ -2,7 +2,6 @@ from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand
 from guardian.shortcuts import remove_perm
 
-from services.enums import ServiceType
 from services.models import Service
 
 available_permissions = [item[0] for item in Service._meta.permissions]
@@ -13,9 +12,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "service_type",
-            type=str,
-            help="Service type (must match service type in the model)",
+            "service", type=str, help="Service, identified by its name",
         )
         parser.add_argument(
             "group_name",
@@ -32,21 +29,21 @@ class Command(BaseCommand):
         try:
             if kwargs["permission"] not in available_permissions:
                 raise ValueError
-            service_type = kwargs["service_type"]
-            service = Service.objects.get(service_type=ServiceType[service_type])
+            service_name = kwargs["service"]
+            service = Service.objects.get(name=service_name)
             group = Group.objects.get(name=kwargs["group_name"])
             permission = kwargs["permission"]
             remove_perm(permission, group, service)
             self.stdout.write(
                 self.style.SUCCESS(
                     "Permission {} removed for {} on service {}".format(
-                        permission, group, service.service_type
+                        permission, group, service.name
                     )
                 )
             )
 
         except Service.DoesNotExist:
-            self.stdout.write(self.style.ERROR("Invalid service_type given"))
+            self.stdout.write(self.style.ERROR("Invalid service given"))
         except Group.DoesNotExist:
             self.stdout.write(self.style.ERROR("Invalid group_name given"))
         except ValueError:

--- a/services/management/commands/remove_object_permission.py
+++ b/services/management/commands/remove_object_permission.py
@@ -1,50 +1,19 @@
-from django.contrib.auth.models import Group
-from django.core.management.base import BaseCommand
 from guardian.shortcuts import remove_perm
 
-from services.models import Service
+from services.management.commands.object_permission_command import (
+    ObjectPermissionCommand,
+)
 
-available_permissions = [item[0] for item in Service._meta.permissions]
 
-
-class Command(BaseCommand):
+class Command(ObjectPermissionCommand):
     help = "Remove service permissions for groups"
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "service", type=str, help="Service, identified by its name",
-        )
-        parser.add_argument(
-            "group_name",
-            type=str,
-            help="Group name (must match group name in the model)",
-        )
-        parser.add_argument(
-            "permission",
-            type=str,
-            help="Permission (options: {})".format(", ".join(available_permissions)),
-        )
-
-    def handle(self, *args, **kwargs):
-        try:
-            if kwargs["permission"] not in available_permissions:
-                raise ValueError
-            service_name = kwargs["service"]
-            service = Service.objects.get(name=service_name)
-            group = Group.objects.get(name=kwargs["group_name"])
-            permission = kwargs["permission"]
-            remove_perm(permission, group, service)
-            self.stdout.write(
-                self.style.SUCCESS(
-                    "Permission {} removed for {} on service {}".format(
-                        permission, group, service.name
-                    )
+    def do_handle(self, permission, group, service):
+        remove_perm(permission, group, service)
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Permission {} removed for {} on service {}".format(
+                    permission, group, service.name
                 )
             )
-
-        except Service.DoesNotExist:
-            self.stdout.write(self.style.ERROR("Invalid service given"))
-        except Group.DoesNotExist:
-            self.stdout.write(self.style.ERROR("Invalid group_name given"))
-        except ValueError:
-            self.stdout.write(self.style.ERROR("Invalid permission given"))
+        )

--- a/services/tests/factories.py
+++ b/services/tests/factories.py
@@ -8,11 +8,9 @@ from services.models import (
     ServiceConnection,
 )
 
-from ..enums import ServiceType
-
 
 class ServiceFactory(factory.django.DjangoModelFactory):
-    service_type = ServiceType.BERTH
+    service_type = None
     name = factory.Sequence(lambda n: "service %d" % n)
 
     @factory.lazy_attribute

--- a/services/tests/test_commands.py
+++ b/services/tests/test_commands.py
@@ -29,27 +29,23 @@ def test_command_add_object_permissions_with_correct_arguments_output(
     assert not user.has_perm("can_manage_profiles", service)
     out = StringIO()
     args = [
-        ServiceType.BERTH.name,
+        service.name,
         group.name,
         "can_view_profiles",
     ]
     call_command("add_object_permission", *args, stdout=out)
     args = [
-        ServiceType.BERTH.name,
+        service.name,
         group.name,
         "can_manage_profiles",
     ]
     call_command("add_object_permission", *args, stdout=out)
     assert (
-        "Permission can_view_profiles added for {0} on service {1}".format(
-            group.name, ServiceType.BERTH.name.capitalize()
-        )
+        f"Permission can_view_profiles added for {group.name} on service {service.name}"
         in out.getvalue()
     )
     assert (
-        "Permission can_manage_profiles added for {0} on service {1}".format(
-            group.name, ServiceType.BERTH.name.capitalize()
-        )
+        f"Permission can_manage_profiles added for {group.name} on service {service.name}"
         in out.getvalue()
     )
     assert user.has_perm("can_view_profiles", service)
@@ -62,7 +58,7 @@ def test_command_add_object_permissions_errors_out_when_invalid_permission_given
     user.groups.add(group)
     out = StringIO()
     args = [
-        ServiceType.BERTH.name,
+        service.name,
         group.name,
         "can_manage_profiles_invalid",
     ]
@@ -77,7 +73,7 @@ def test_command_add_object_permissions_errors_out_when_invalid_group_name_given
     user.groups.add(group)
     out = StringIO()
     args = [
-        ServiceType.BERTH.name,
+        service.name,
         "InvalidGroup",
         "can_manage_profiles",
     ]
@@ -86,18 +82,18 @@ def test_command_add_object_permissions_errors_out_when_invalid_group_name_given
     assert not user.has_perm("can_manage_profiles", service)
 
 
-def test_command_add_object_permissions_throws_error_when_invalid_service_type_given(
+def test_command_add_object_permissions_errors_out_when_invalid_service_given(
     user, service, group
 ):
     user.groups.add(group)
     out = StringIO()
     args = [
-        "BERTH_INVALID",
+        "INVALID",
         group.name,
         "can_manage_profiles",
     ]
-    with pytest.raises(KeyError):
-        call_command("add_object_permission", *args, stdout=out)
+    call_command("add_object_permission", *args, stdout=out)
+    assert "Invalid service given" in out.getvalue()
     assert not user.has_perm("can_manage_profiles", service)
 
 

--- a/services/tests/test_commands.py
+++ b/services/tests/test_commands.py
@@ -4,7 +4,6 @@ import pytest
 from django.core.management import call_command
 from guardian.shortcuts import assign_perm
 
-from open_city_profile.tests.factories import GroupFactory
 from services.enums import ServiceType
 from services.models import Service
 
@@ -22,33 +21,34 @@ def test_command_generate_services_adds_only_missing_services(service):
     assert Service.objects.count() == len(ServiceType)
 
 
-def test_command_add_object_permissions_with_correct_arguments_output(user, service):
-    group = GroupFactory(name="{}Admin".format(ServiceType.BERTH.name.capitalize()))
+def test_command_add_object_permissions_with_correct_arguments_output(
+    user, service, group
+):
     user.groups.add(group)
     assert not user.has_perm("can_view_profiles", service)
     assert not user.has_perm("can_manage_profiles", service)
     out = StringIO()
     args = [
         ServiceType.BERTH.name,
-        "{}Admin".format(ServiceType.BERTH.name.capitalize()),
+        group.name,
         "can_view_profiles",
     ]
     call_command("add_object_permission", *args, stdout=out)
     args = [
         ServiceType.BERTH.name,
-        "{}Admin".format(ServiceType.BERTH.name.capitalize()),
+        group.name,
         "can_manage_profiles",
     ]
     call_command("add_object_permission", *args, stdout=out)
     assert (
-        "Permission can_view_profiles added for {0}Admin on service {0}".format(
-            ServiceType.BERTH.name.capitalize()
+        "Permission can_view_profiles added for {0} on service {1}".format(
+            group.name, ServiceType.BERTH.name.capitalize()
         )
         in out.getvalue()
     )
     assert (
-        "Permission can_manage_profiles added for {0}Admin on service {0}".format(
-            ServiceType.BERTH.name.capitalize()
+        "Permission can_manage_profiles added for {0} on service {1}".format(
+            group.name, ServiceType.BERTH.name.capitalize()
         )
         in out.getvalue()
     )
@@ -56,15 +56,14 @@ def test_command_add_object_permissions_with_correct_arguments_output(user, serv
     assert user.has_perm("can_manage_profiles", service)
 
 
-def test_command_add_object_permissions_throws_error_when_invalid_permission_given(
-    user, service
+def test_command_add_object_permissions_errors_out_when_invalid_permission_given(
+    user, service, group
 ):
-    group = GroupFactory(name="{}Admin".format(ServiceType.BERTH.name.capitalize()))
     user.groups.add(group)
     out = StringIO()
     args = [
         ServiceType.BERTH.name,
-        "{}Admin".format(ServiceType.BERTH.name.capitalize()),
+        group.name,
         "can_manage_profiles_invalid",
     ]
     call_command("add_object_permission", *args, stdout=out)
@@ -72,15 +71,14 @@ def test_command_add_object_permissions_throws_error_when_invalid_permission_giv
     assert not user.has_perm("can_manage_profiles_invalid", service)
 
 
-def test_command_add_object_permissions_throws_error_when_invalid_group_name_given(
-    user, service
+def test_command_add_object_permissions_errors_out_when_invalid_group_name_given(
+    user, service, group
 ):
-    group = GroupFactory(name="{}Admin".format(ServiceType.BERTH.name.capitalize()))
     user.groups.add(group)
     out = StringIO()
     args = [
         ServiceType.BERTH.name,
-        "{}AdminInvalid".format(ServiceType.BERTH.name.capitalize()),
+        "InvalidGroup",
         "can_manage_profiles",
     ]
     call_command("add_object_permission", *args, stdout=out)
@@ -89,14 +87,13 @@ def test_command_add_object_permissions_throws_error_when_invalid_group_name_giv
 
 
 def test_command_add_object_permissions_throws_error_when_invalid_service_type_given(
-    user, service
+    user, service, group
 ):
-    group = GroupFactory(name="{}Admin".format(ServiceType.BERTH.name.capitalize()))
     user.groups.add(group)
     out = StringIO()
     args = [
         "BERTH_INVALID",
-        "{}Admin".format(ServiceType.BERTH.name.capitalize()),
+        group.name,
         "can_manage_profiles",
     ]
     with pytest.raises(KeyError):
@@ -104,8 +101,9 @@ def test_command_add_object_permissions_throws_error_when_invalid_service_type_g
     assert not user.has_perm("can_manage_profiles", service)
 
 
-def test_command_remove_object_permissions_with_correct_arguments_output(user, service):
-    group = GroupFactory(name="{}Admin".format(ServiceType.BERTH.name.capitalize()))
+def test_command_remove_object_permissions_with_correct_arguments_output(
+    user, service, group
+):
     user.groups.add(group)
     assign_perm("can_view_profiles", group, service)
     assign_perm("can_manage_profiles", group, service)
@@ -114,25 +112,25 @@ def test_command_remove_object_permissions_with_correct_arguments_output(user, s
     out = StringIO()
     args = [
         ServiceType.BERTH.name,
-        "{}Admin".format(ServiceType.BERTH.name.capitalize()),
+        group.name,
         "can_view_profiles",
     ]
     call_command("remove_object_permission", *args, stdout=out)
     args = [
         ServiceType.BERTH.name,
-        "{}Admin".format(ServiceType.BERTH.name.capitalize()),
+        group.name,
         "can_manage_profiles",
     ]
     call_command("remove_object_permission", *args, stdout=out)
     assert (
-        "Permission can_view_profiles removed for {0}Admin on service {0}".format(
-            ServiceType.BERTH.name.capitalize()
+        "Permission can_view_profiles removed for {0} on service {1}".format(
+            group.name, ServiceType.BERTH.name.capitalize()
         )
         in out.getvalue()
     )
     assert (
-        "Permission can_manage_profiles removed for {0}Admin on service {0}".format(
-            ServiceType.BERTH.name.capitalize()
+        "Permission can_manage_profiles removed for {0} on service {1}".format(
+            group.name, ServiceType.BERTH.name.capitalize()
         )
         in out.getvalue()
     )
@@ -140,17 +138,16 @@ def test_command_remove_object_permissions_with_correct_arguments_output(user, s
     assert not user.has_perm("can_manage_profiles", service)
 
 
-def test_command_remove_object_permissions_throws_error_when_invalid_permission_given(
-    user, service
+def test_command_remove_object_permissions_errors_out_when_invalid_permission_given(
+    user, service, group
 ):
-    group = GroupFactory(name="{}Admin".format(ServiceType.BERTH.name.capitalize()))
     user.groups.add(group)
     assign_perm("can_manage_profiles", group, service)
     assert user.has_perm("can_manage_profiles", service)
     out = StringIO()
     args = [
         ServiceType.BERTH.name,
-        "{}Admin".format(ServiceType.BERTH.name.capitalize()),
+        group.name,
         "can_manage_profiles_invalid",
     ]
     call_command("remove_object_permission", *args, stdout=out)
@@ -158,17 +155,16 @@ def test_command_remove_object_permissions_throws_error_when_invalid_permission_
     assert user.has_perm("can_manage_profiles", service)
 
 
-def test_command_remove_object_permissions_throws_error_when_invalid_group_name_given(
-    user, service
+def test_command_remove_object_permissions_errors_out_when_invalid_group_name_given(
+    user, service, group
 ):
-    group = GroupFactory(name="{}Admin".format(ServiceType.BERTH.name.capitalize()))
     user.groups.add(group)
     assign_perm("can_manage_profiles", group, service)
     assert user.has_perm("can_manage_profiles", service)
     out = StringIO()
     args = [
         ServiceType.BERTH.name,
-        "{}AdminInvalid".format(ServiceType.BERTH.name.capitalize()),
+        "InvalidGroup",
         "can_manage_profiles",
     ]
     call_command("remove_object_permission", *args, stdout=out)
@@ -177,16 +173,15 @@ def test_command_remove_object_permissions_throws_error_when_invalid_group_name_
 
 
 def test_command_remove_object_permissions_throws_error_when_invalid_service_type_given(
-    user, service
+    user, service, group
 ):
-    group = GroupFactory(name="{}Admin".format(ServiceType.BERTH.name.capitalize()))
     user.groups.add(group)
     assign_perm("can_manage_profiles", group, service)
     assert user.has_perm("can_manage_profiles", service)
     out = StringIO()
     args = [
         "BERTH_INVALID",
-        "{}Admin".format(ServiceType.BERTH.name.capitalize()),
+        group.name,
         "can_manage_profiles",
     ]
     with pytest.raises(KeyError):

--- a/services/tests/test_commands.py
+++ b/services/tests/test_commands.py
@@ -15,6 +15,7 @@ def test_command_generate_services_adds_all_services():
     assert Service.objects.count() == len(ServiceType)
 
 
+@pytest.mark.parametrize("service__name", ["berth"])
 def test_command_generate_services_adds_only_missing_services(service):
     assert Service.objects.count() == 1
     call_command("generate_services")

--- a/services/tests/test_commands.py
+++ b/services/tests/test_commands.py
@@ -107,27 +107,23 @@ def test_command_remove_object_permissions_with_correct_arguments_output(
     assert user.has_perm("can_manage_profiles", service)
     out = StringIO()
     args = [
-        ServiceType.BERTH.name,
+        service.name,
         group.name,
         "can_view_profiles",
     ]
     call_command("remove_object_permission", *args, stdout=out)
     args = [
-        ServiceType.BERTH.name,
+        service.name,
         group.name,
         "can_manage_profiles",
     ]
     call_command("remove_object_permission", *args, stdout=out)
     assert (
-        "Permission can_view_profiles removed for {0} on service {1}".format(
-            group.name, ServiceType.BERTH.name.capitalize()
-        )
+        f"Permission can_view_profiles removed for {group.name} on service {service.name}"
         in out.getvalue()
     )
     assert (
-        "Permission can_manage_profiles removed for {0} on service {1}".format(
-            group.name, ServiceType.BERTH.name.capitalize()
-        )
+        f"Permission can_manage_profiles removed for {group.name} on service {service.name}"
         in out.getvalue()
     )
     assert not user.has_perm("can_view_profiles", service)
@@ -142,7 +138,7 @@ def test_command_remove_object_permissions_errors_out_when_invalid_permission_gi
     assert user.has_perm("can_manage_profiles", service)
     out = StringIO()
     args = [
-        ServiceType.BERTH.name,
+        service.name,
         group.name,
         "can_manage_profiles_invalid",
     ]
@@ -159,7 +155,7 @@ def test_command_remove_object_permissions_errors_out_when_invalid_group_name_gi
     assert user.has_perm("can_manage_profiles", service)
     out = StringIO()
     args = [
-        ServiceType.BERTH.name,
+        service.name,
         "InvalidGroup",
         "can_manage_profiles",
     ]
@@ -168,7 +164,7 @@ def test_command_remove_object_permissions_errors_out_when_invalid_group_name_gi
     assert user.has_perm("can_manage_profiles", service)
 
 
-def test_command_remove_object_permissions_throws_error_when_invalid_service_type_given(
+def test_command_remove_object_permissions_errors_out_when_invalid_service_given(
     user, service, group
 ):
     user.groups.add(group)
@@ -176,10 +172,10 @@ def test_command_remove_object_permissions_throws_error_when_invalid_service_typ
     assert user.has_perm("can_manage_profiles", service)
     out = StringIO()
     args = [
-        "BERTH_INVALID",
+        "INVALID",
         group.name,
         "can_manage_profiles",
     ]
-    with pytest.raises(KeyError):
-        call_command("remove_object_permission", *args, stdout=out)
+    call_command("remove_object_permission", *args, stdout=out)
+    assert "Invalid service given" in out.getvalue()
     assert user.has_perm("can_manage_profiles", service)

--- a/services/tests/test_commands.py
+++ b/services/tests/test_commands.py
@@ -1,7 +1,7 @@
 from io import StringIO
 
 import pytest
-from django.core.management import call_command
+from django.core.management import call_command, CommandError
 from guardian.shortcuts import assign_perm
 
 from services.enums import ServiceType
@@ -56,14 +56,13 @@ def test_command_add_object_permissions_errors_out_when_invalid_permission_given
     user, service, group
 ):
     user.groups.add(group)
-    out = StringIO()
     args = [
         service.name,
         group.name,
         "can_manage_profiles_invalid",
     ]
-    call_command("add_object_permission", *args, stdout=out)
-    assert "Invalid permission given" in out.getvalue()
+    with pytest.raises(CommandError, match="Invalid permission given"):
+        call_command("add_object_permission", *args)
     assert not user.has_perm("can_manage_profiles_invalid", service)
 
 
@@ -71,14 +70,13 @@ def test_command_add_object_permissions_errors_out_when_invalid_group_name_given
     user, service, group
 ):
     user.groups.add(group)
-    out = StringIO()
     args = [
         service.name,
         "InvalidGroup",
         "can_manage_profiles",
     ]
-    call_command("add_object_permission", *args, stdout=out)
-    assert "Invalid group_name given" in out.getvalue()
+    with pytest.raises(CommandError, match="Invalid group_name given"):
+        call_command("add_object_permission", *args)
     assert not user.has_perm("can_manage_profiles", service)
 
 
@@ -86,14 +84,13 @@ def test_command_add_object_permissions_errors_out_when_invalid_service_given(
     user, service, group
 ):
     user.groups.add(group)
-    out = StringIO()
     args = [
         "INVALID",
         group.name,
         "can_manage_profiles",
     ]
-    call_command("add_object_permission", *args, stdout=out)
-    assert "Invalid service given" in out.getvalue()
+    with pytest.raises(CommandError, match="Invalid service given"):
+        call_command("add_object_permission", *args)
     assert not user.has_perm("can_manage_profiles", service)
 
 
@@ -136,14 +133,13 @@ def test_command_remove_object_permissions_errors_out_when_invalid_permission_gi
     user.groups.add(group)
     assign_perm("can_manage_profiles", group, service)
     assert user.has_perm("can_manage_profiles", service)
-    out = StringIO()
     args = [
         service.name,
         group.name,
         "can_manage_profiles_invalid",
     ]
-    call_command("remove_object_permission", *args, stdout=out)
-    assert "Invalid permission given" in out.getvalue()
+    with pytest.raises(CommandError, match="Invalid permission given"):
+        call_command("remove_object_permission", *args)
     assert user.has_perm("can_manage_profiles", service)
 
 
@@ -153,14 +149,13 @@ def test_command_remove_object_permissions_errors_out_when_invalid_group_name_gi
     user.groups.add(group)
     assign_perm("can_manage_profiles", group, service)
     assert user.has_perm("can_manage_profiles", service)
-    out = StringIO()
     args = [
         service.name,
         "InvalidGroup",
         "can_manage_profiles",
     ]
-    call_command("remove_object_permission", *args, stdout=out)
-    assert "Invalid group_name given" in out.getvalue()
+    with pytest.raises(CommandError, match="Invalid group_name given"):
+        call_command("remove_object_permission", *args)
     assert user.has_perm("can_manage_profiles", service)
 
 
@@ -170,12 +165,11 @@ def test_command_remove_object_permissions_errors_out_when_invalid_service_given
     user.groups.add(group)
     assign_perm("can_manage_profiles", group, service)
     assert user.has_perm("can_manage_profiles", service)
-    out = StringIO()
     args = [
         "INVALID",
         group.name,
         "can_manage_profiles",
     ]
-    call_command("remove_object_permission", *args, stdout=out)
-    assert "Invalid service given" in out.getvalue()
+    with pytest.raises(CommandError, match="Invalid service given"):
+        call_command("remove_object_permission", *args)
     assert user.has_perm("can_manage_profiles", service)

--- a/services/tests/test_models.py
+++ b/services/tests/test_models.py
@@ -24,10 +24,10 @@ def test_generate_services_without_service_type(service_factory):
 
 @pytest.mark.django_db(transaction=True)
 def test_add_service_with_duplicate_service_type(service_factory):
-    service_factory()
+    service_factory(service_type=ServiceType.BERTH)
     assert Service.objects.count() == 1
     with pytest.raises(IntegrityError):
-        service_factory()
+        service_factory(service_type=ServiceType.BERTH)
     assert Service.objects.count() == 1
 
 

--- a/services/tests/test_services_graphql_api.py
+++ b/services/tests/test_services_graphql_api.py
@@ -1,11 +1,15 @@
+import pytest
+
 from open_city_profile.consts import (
     SERVICE_CONNECTION_ALREADY_EXISTS_ERROR,
     SERVICE_NOT_IDENTIFIED_ERROR,
 )
 from open_city_profile.tests.asserts import assert_match_error_code
+from services.enums import ServiceType
 from services.tests.factories import ProfileFactory, ServiceConnectionFactory
 
 
+@pytest.mark.parametrize("service__service_type", [ServiceType.BERTH])
 def test_normal_user_can_query_own_services(
     user_gql_client, service, allowed_data_field_factory
 ):
@@ -81,6 +85,7 @@ def test_normal_user_can_query_own_services(
     assert executed["data"] == expected_data
 
 
+@pytest.mark.parametrize("service__service_type", [ServiceType.BERTH])
 def test_normal_user_can_add_service(user_gql_client, service):
     ProfileFactory(user=user_gql_client.user)
 
@@ -118,6 +123,7 @@ def test_normal_user_can_add_service(user_gql_client, service):
     assert executed["data"] == expected_data
 
 
+@pytest.mark.parametrize("service__service_type", [ServiceType.BERTH])
 def test_normal_user_cannot_add_service_multiple_times_mutation(
     user_gql_client, service
 ):
@@ -192,7 +198,9 @@ def test_normal_user_can_query_own_services_gdpr_api_scopes(
     query_scope = "query_scope"
     delete_scope = "delete_scope"
     service = service_factory(
-        gdpr_query_scope=query_scope, gdpr_delete_scope=delete_scope
+        service_type=ServiceType.BERTH,
+        gdpr_query_scope=query_scope,
+        gdpr_delete_scope=delete_scope,
     )
     profile = ProfileFactory(user=user_gql_client.user)
 

--- a/utils/tests/test_utils.py
+++ b/utils/tests/test_utils.py
@@ -47,7 +47,7 @@ def test_generate_group_for_service(times, service):
 def test_assign_permissions(times, user, service):
     available_permissions = [item[0] for item in Service._meta.permissions]
     # assign_permissions expects a Group and a Service exist with the same name.
-    group = GroupFactory(name=service.service_type)
+    group = GroupFactory(name=service.name)
     user.groups.add(group)
 
     for permission in available_permissions:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -89,6 +89,7 @@ SERVICES = [
                 "description": "Båtplatser i Helsingfors båthamnar.",
             },
         },
+        "allowed_data_fields": ["name", "email", "address", "phone", "ssn"],
     },
     {
         "name": "youth_membership",
@@ -109,6 +110,7 @@ SERVICES = [
                 "erbjuds av Helsingfors ungdomscenter.",
             },
         },
+        "allowed_data_fields": ["name", "email", "address", "phone"],
     },
     {
         "name": "godchildren_of_culture",
@@ -129,8 +131,12 @@ SERVICES = [
                 "födda i Helsingfors 2020.",
             },
         },
+        "allowed_data_fields": ["name", "email", "address", "phone"],
     },
-    {"name": "hki_my_data"},
+    {
+        "name": "hki_my_data",
+        "allowed_data_fields": ["name", "email", "address", "phone"],
+    },
 ]
 
 
@@ -152,9 +158,12 @@ def generate_services():
                 for field, text in translations.items():
                     setattr(service, field, text)
             service.save()
-            for field in AllowedDataField.objects.all():
-                if field.field_name != "ssn" or service.name == "berth":
-                    service.allowed_data_fields.add(field)
+
+            allowed_data_fields = service_spec.get("allowed_data_fields", [])
+            for field in AllowedDataField.objects.filter(
+                field_name__in=allowed_data_fields
+            ):
+                service.allowed_data_fields.add(field)
         services.append(service)
     return services
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -157,7 +157,7 @@ def generate_groups_for_services(services=tuple()):
     """Create groups for given services unless they already exist."""
     groups = []
     for service in services:
-        group, created = Group.objects.get_or_create(name=service.service_type.value)
+        group, created = Group.objects.get_or_create(name=service.name)
         groups.append(group)
     return groups
 
@@ -169,7 +169,7 @@ def assign_permissions(groups=tuple()):
     """
     available_permissions = [item[0] for item in Service._meta.permissions]
     for group in groups:
-        service = Service.objects.get(service_type=group.name)
+        service = Service.objects.get(name=group.name)
         if service:
             for permission in available_permissions:
                 assign_perm(permission, group, service)


### PR DESCRIPTION
The `Service`'s `service_type` field is obsolete. It can be removed from the code base, except the few places where it still remains for backwards compatibility.

The changes in this PR are those that were needed to achieve the last commit, which removes the `service_type = ServiceType.BERTH` from `ServiceFactory`. The changes seem to mostly concern the tools and utilities.

There are many places where `service_type` is still used even after this PR. But those are subject for another PR(s).