### PR TITLE
Cleaning up service types and mentions of "berth" or "youth" (part 2 of 2)

### DIFF
--- a/open_city_profile/tests/conftest.py
+++ b/open_city_profile/tests/conftest.py
@@ -59,9 +59,7 @@ class GraphQLClient(GrapheneClient):
             context.service = None
 
         if service is _not_provided:
-            context.service = ServiceFactory(
-                service_type=None, implicit_connection=True,
-            )
+            context.service = ServiceFactory(implicit_connection=True)
         elif service:
             context.service = service
 

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1383,9 +1383,8 @@ class Mutation(graphene.ObjectType):
     # TODO: Add the complete list of error codes
     delete_my_profile = DeleteMyProfileMutation.Field(
         description="Deletes the data of the profile which is linked to the currently authenticated user.\n\n"
-        "Requires authentication.\n\nPossible error codes:\n\n* "
-        "`CANNOT_DELETE_PROFILE_WHILE_SERVICE_CONNECTED_ERROR`: Returned if the profile is connected to "
-        "Berth service.\n\n* `PROFILE_DOES_NOT_EXIST_ERROR`: Returned if there is no profile linked to "
+        "Requires authentication.\n\nPossible error codes:\n\n"
+        "* `PROFILE_DOES_NOT_EXIST_ERROR`: Returned if there is no profile linked to "
         "the currently authenticated user.\n\n* `TODO`"
     )
     # TODO: Add the complete list of error codes

--- a/profiles/tests/test_gql_create_or_update_profile_with_verified_personal_information_mutation.py
+++ b/profiles/tests/test_gql_create_or_update_profile_with_verified_personal_information_mutation.py
@@ -15,7 +15,6 @@ from profiles.models import (
     VerifiedPersonalInformationTemporaryAddress,
 )
 from profiles.tests.factories import EmailFactory
-from services.enums import ServiceType
 
 from .conftest import (
     VERIFIED_PERSONAL_INFORMATION_ADDRESS_FIELD_NAMES,
@@ -398,8 +397,8 @@ def test_add_new_service_connections(
     service_factory, service_client_id_factory, user_gql_client
 ):
     user_id = uuid.uuid1()
-    service1 = service_factory(service_type=ServiceType.BERTH)
-    service2 = service_factory(service_type=ServiceType.YOUTH_MEMBERSHIP)
+    service1 = service_factory()
+    service2 = service_factory()
     service_client_id_factory(service=service1)
     service_client_id_factory(service=service2)
 

--- a/profiles/tests/test_gql_create_profile_mutation.py
+++ b/profiles/tests/test_gql_create_profile_mutation.py
@@ -225,8 +225,8 @@ def test_staff_user_with_sensitive_data_service_accesss_can_create_a_profile_wit
 def test_staff_user_cannot_create_a_profile_with_sensitive_data_without_sensitive_data_service_access(
     user_gql_client, service_factory
 ):
-    service_berth = service_factory(service_type=ServiceType.BERTH)
-    service_youth = service_factory(service_type=ServiceType.YOUTH_MEMBERSHIP)
+    service_berth = service_factory()
+    service_youth = service_factory()
     group_berth = GroupFactory(name=ServiceType.BERTH.value)
     group_youth = GroupFactory(name="youth_membership")
     user = user_gql_client.user

--- a/profiles/tests/test_gql_profile_query.py
+++ b/profiles/tests/test_gql_profile_query.py
@@ -7,7 +7,6 @@ from guardian.shortcuts import assign_perm
 
 from open_city_profile.consts import OBJECT_DOES_NOT_EXIST_ERROR
 from open_city_profile.tests.asserts import assert_match_error_code
-from services.enums import ServiceType
 from services.tests.factories import ServiceConnectionFactory
 
 from ..schema import ProfileNode
@@ -93,7 +92,7 @@ def test_staff_user_cannot_query_a_profile_without_a_connection_to_their_service
     user_gql_client, profile, group, service_factory
 ):
     service_berth = service_factory()
-    service_youth = service_factory(service_type=ServiceType.YOUTH_MEMBERSHIP)
+    service_youth = service_factory()
     ServiceConnectionFactory(profile=profile, service=service_berth)
     user = user_gql_client.user
     user.groups.add(group)

--- a/profiles/tests/test_gql_profiles_query.py
+++ b/profiles/tests/test_gql_profiles_query.py
@@ -8,7 +8,6 @@ from guardian.shortcuts import assign_perm
 from open_city_profile.tests import to_graphql_name
 from open_city_profile.tests.asserts import assert_match_error_code
 from profiles.enums import AddressType, EmailType, PhoneType
-from services.enums import ServiceType
 from services.tests.factories import ServiceConnectionFactory
 from subscriptions.models import Subscription
 from subscriptions.tests.factories import (
@@ -803,8 +802,8 @@ def test_staff_user_with_group_access_can_query_only_profiles_he_has_access_to(
 ):
     profile_berth = ProfileFactory()
     profile_youth = ProfileFactory()
-    service_berth = service_factory(service_type=ServiceType.BERTH)
-    service_youth = service_factory(service_type=ServiceType.YOUTH_MEMBERSHIP)
+    service_berth = service_factory()
+    service_youth = service_factory()
     ServiceConnectionFactory(profile=profile_berth, service=service_berth)
     ServiceConnectionFactory(profile=profile_youth, service=service_youth)
     user = user_gql_client.user

--- a/profiles/tests/test_gql_profiles_query.py
+++ b/profiles/tests/test_gql_profiles_query.py
@@ -137,7 +137,7 @@ def test_staff_user_can_filter_profiles_by_profile_ids(user_gql_client, group, s
 
 query_template = Template(
     """
-        query getBerthProfiles($$searchString: String) {
+        query getProfiles($$searchString: String) {
             profiles(${search_arg_name}: $$searchString) {
                 count
                 totalCount
@@ -231,7 +231,7 @@ def test_staff_user_can_sort_profiles(user_gql_client, group, service):
     assign_perm("can_view_profiles", group, service)
 
     query = """
-        query getBerthProfiles {
+        query getProfiles {
             profiles(orderBy: "-firstName") {
                 edges {
                     node {
@@ -294,7 +294,7 @@ def test_staff_user_can_sort_profiles_by_custom_fields(
 
     t = Template(
         """
-        query getBerthProfiles {
+        query getProfiles {
             profiles(orderBy: "${order_by}") {
                 edges {
                     node {
@@ -341,7 +341,7 @@ def test_staff_user_can_filter_profiles_by_emails(user_gql_client, group, servic
     # filter by email
 
     query = """
-        query getBerthProfiles($email: String) {
+        query getProfiles($email: String) {
             profiles(emails_Email: $email) {
                 count
                 totalCount
@@ -359,7 +359,7 @@ def test_staff_user_can_filter_profiles_by_emails(user_gql_client, group, servic
     # filter by email_type
 
     query = """
-        query getBerthProfiles($emailType: String) {
+        query getProfiles($emailType: String) {
             profiles(emails_EmailType: $emailType) {
                 count
                 totalCount
@@ -377,7 +377,7 @@ def test_staff_user_can_filter_profiles_by_emails(user_gql_client, group, servic
     # filter by primary
 
     query = """
-        query getBerthProfiles($primary: Boolean) {
+        query getProfiles($primary: Boolean) {
             profiles(emails_Primary: $primary) {
                 count
                 totalCount
@@ -395,7 +395,7 @@ def test_staff_user_can_filter_profiles_by_emails(user_gql_client, group, servic
     # filter by verified
 
     query = """
-        query getBerthProfiles($verified: Boolean) {
+        query getProfiles($verified: Boolean) {
             profiles(emails_Verified: $verified) {
                 count
                 totalCount
@@ -426,7 +426,7 @@ def test_staff_user_can_filter_profiles_by_phones(user_gql_client, group, servic
     # filter by phone
 
     query = """
-        query getBerthProfiles($phone: String) {
+        query getProfiles($phone: String) {
             profiles(phones_Phone: $phone) {
                 count
                 totalCount
@@ -444,7 +444,7 @@ def test_staff_user_can_filter_profiles_by_phones(user_gql_client, group, servic
     # filter by phone_type
 
     query = """
-        query getBerthProfiles($phoneType: String) {
+        query getProfiles($phoneType: String) {
             profiles(phones_PhoneType: $phoneType) {
                 count
                 totalCount
@@ -462,7 +462,7 @@ def test_staff_user_can_filter_profiles_by_phones(user_gql_client, group, servic
     # filter by primary
 
     query = """
-        query getBerthProfiles($primary: Boolean) {
+        query getProfiles($primary: Boolean) {
             profiles(phones_Primary: $primary) {
                 count
                 totalCount
@@ -514,7 +514,7 @@ def test_staff_user_can_filter_profiles_by_addresses(user_gql_client, group, ser
     # filter by address
 
     query = """
-        query getBerthProfiles($address: String) {
+        query getProfiles($address: String) {
             profiles(addresses_Address: $address) {
                 count
                 totalCount
@@ -532,7 +532,7 @@ def test_staff_user_can_filter_profiles_by_addresses(user_gql_client, group, ser
     # filter by postal_code
 
     query = """
-        query getBerthProfiles($postalCode: String) {
+        query getProfiles($postalCode: String) {
             profiles(addresses_PostalCode: $postalCode) {
                 count
                 totalCount
@@ -550,7 +550,7 @@ def test_staff_user_can_filter_profiles_by_addresses(user_gql_client, group, ser
     # filter by city
 
     query = """
-        query getBerthProfiles($city: String) {
+        query getProfiles($city: String) {
             profiles(addresses_City: $city) {
                 count
                 totalCount
@@ -568,7 +568,7 @@ def test_staff_user_can_filter_profiles_by_addresses(user_gql_client, group, ser
     # filter by country code
 
     query = """
-        query getBerthProfiles($countryCode: String) {
+        query getProfiles($countryCode: String) {
             profiles(addresses_CountryCode: $countryCode) {
                 count
                 totalCount
@@ -586,7 +586,7 @@ def test_staff_user_can_filter_profiles_by_addresses(user_gql_client, group, ser
     # filter by address_type
 
     query = """
-        query getBerthProfiles($addressType: String) {
+        query getProfiles($addressType: String) {
             profiles(addresses_AddressType: $addressType) {
                 count
                 totalCount
@@ -604,7 +604,7 @@ def test_staff_user_can_filter_profiles_by_addresses(user_gql_client, group, ser
     # filter by primary
 
     query = """
-        query getBerthProfiles($primary: Boolean) {
+        query getProfiles($primary: Boolean) {
             profiles(addresses_Primary: $primary) {
                 count
                 totalCount
@@ -697,7 +697,7 @@ def test_staff_user_can_filter_profiles_by_subscriptions_and_postal_code(
     assign_perm("can_view_profiles", group, service)
 
     query = """
-        query getBerthProfiles($subscriptionType: String, $postalCode: String) {
+        query getProfiles($subscriptionType: String, $postalCode: String) {
             profiles(
                 enabledSubscriptions: $subscriptionType,
                 addresses_PostalCode: $postalCode
@@ -755,7 +755,7 @@ def test_staff_user_can_paginate_profiles(user_gql_client, group, service):
     assign_perm("can_view_profiles", group, service)
 
     query = """
-        query getBerthProfiles {
+        query getProfiles {
             profiles(orderBy: "firstName", first: 1) {
                 pageInfo {
                     endCursor
@@ -779,7 +779,7 @@ def test_staff_user_can_paginate_profiles(user_gql_client, group, service):
     end_cursor = executed["data"]["profiles"]["pageInfo"]["endCursor"]
 
     query = """
-        query getBerthProfiles($endCursor: String) {
+        query getProfiles($endCursor: String) {
             profiles(first: 1, after: $endCursor) {
                 edges {
                     node {

--- a/profiles/tests/test_gql_update_profile_mutation.py
+++ b/profiles/tests/test_gql_update_profile_mutation.py
@@ -8,7 +8,6 @@ from guardian.shortcuts import assign_perm
 from open_city_profile.tests.asserts import assert_match_error_code
 from profiles.enums import EmailType
 from profiles.models import Profile
-from services.enums import ServiceType
 from services.tests.factories import ServiceConnectionFactory
 
 from .factories import AddressFactory, PhoneFactory, ProfileWithPrimaryEmailFactory
@@ -184,10 +183,9 @@ def test_staff_user_cannot_update_profile_sensitive_data_without_correct_permiss
 
 
 def test_normal_user_cannot_update_a_profile_using_update_profile_mutation(
-    user_gql_client, service_factory
+    user_gql_client, service
 ):
     profile = ProfileWithPrimaryEmailFactory(first_name="Joe")
-    service = service_factory(service_type=ServiceType.YOUTH_MEMBERSHIP)
     ServiceConnectionFactory(profile=profile, service=service)
 
     t = Template(

--- a/services/tests/conftest.py
+++ b/services/tests/conftest.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest_factoryboy import register
 
 from open_city_profile.tests.conftest import *  # noqa
@@ -8,22 +7,3 @@ from services.tests.factories import AllowedDataFieldFactory, ServiceFactory
 # Register factory fixtures
 register(ServiceFactory)
 register(AllowedDataFieldFactory)
-
-
-@pytest.fixture
-def youth_profile_response():
-    return {
-        "key": "YOUTHPROFILE",
-        "children": [
-            {"key": "BIRTH_DATE", "value": "2004-12-08"},
-            {"key": "SCHOOL_NAME", "value": "Testikoulu"},
-            {"key": "SCHOOL_CLASS", "value": "2B"},
-            {"key": "LANGUAGE_AT_HOME", "value": "fi"},
-            {"key": "APPROVER_FIRST_NAME", "value": "Teppo"},
-            {"key": "APPROVER_LAST_NAME", "value": "Testi"},
-            {"key": "APPROVER_PHONE", "value": "0401234567"},
-            {"key": "APPROVER_EMAIL", "value": "teppo.testi@example.com"},
-            {"key": "EXPIRATION", "value": "2021-08-31 00:00"},
-            {"key": "PHOTO_USAGE_APPROVED", "value": False},
-        ],
-    }

--- a/services/tests/test_commands.py
+++ b/services/tests/test_commands.py
@@ -4,21 +4,21 @@ import pytest
 from django.core.management import call_command, CommandError
 from guardian.shortcuts import assign_perm
 
-from services.enums import ServiceType
 from services.models import Service
+from utils.utils import SERVICES
 
 
 def test_command_generate_services_adds_all_services():
     assert Service.objects.count() == 0
     call_command("generate_services")
-    assert Service.objects.count() == len(ServiceType)
+    assert Service.objects.count() == len(SERVICES)
 
 
 @pytest.mark.parametrize("service__name", ["berth"])
 def test_command_generate_services_adds_only_missing_services(service):
     assert Service.objects.count() == 1
     call_command("generate_services")
-    assert Service.objects.count() == len(ServiceType)
+    assert Service.objects.count() == len(SERVICES)
 
 
 def test_command_add_object_permissions_with_correct_arguments_output(

--- a/services/tests/test_models.py
+++ b/services/tests/test_models.py
@@ -2,18 +2,11 @@ import pytest
 import requests
 from django.db.utils import IntegrityError
 
-from ..enums import ServiceType
 from ..exceptions import MissingGDPRUrlException
 from ..models import Service, ServiceConnection
 from .factories import ProfileFactory, ServiceConnectionFactory
 
 GDPR_URL = "https://example.com/"
-
-
-def test_generate_services_from_enum():
-    for service_type in ServiceType:
-        Service.objects.create(service_type=service_type)
-    assert Service.objects.count() == len(ServiceType)
 
 
 def test_generate_services_without_service_type(service_factory):
@@ -23,11 +16,11 @@ def test_generate_services_without_service_type(service_factory):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_add_service_with_duplicate_service_type(service_factory):
-    service_factory(service_type=ServiceType.BERTH)
+def test_add_service_with_duplicate_name(service_factory):
+    service_factory(name="service_name")
     assert Service.objects.count() == 1
     with pytest.raises(IntegrityError):
-        service_factory(service_type=ServiceType.BERTH)
+        service_factory(name="service_name")
     assert Service.objects.count() == 1
 
 
@@ -51,8 +44,8 @@ def test_connect_same_service_with_different_profile(service):
 
 def test_connect_two_different_services_for_same_profile(service_factory):
     profile = ProfileFactory()
-    service_1 = service_factory(service_type=ServiceType.BERTH)
-    service_2 = service_factory(service_type=ServiceType.YOUTH_MEMBERSHIP)
+    service_1 = service_factory()
+    service_2 = service_factory()
     ServiceConnectionFactory(profile=profile, service=service_1)
     ServiceConnectionFactory(profile=profile, service=service_2)
     assert ServiceConnection.objects.count() == 2

--- a/services/tests/test_models.py
+++ b/services/tests/test_models.py
@@ -59,18 +59,20 @@ def test_allowed_data_fields_get_correct_orders(allowed_data_field_factory):
 
 
 @pytest.mark.parametrize("service__gdpr_url", [GDPR_URL])
-def test_download_gdpr_data_with_valid_service_and_url(
-    requests_mock, youth_profile_response, service, profile
-):
+def test_download_gdpr_data_with_valid_service_and_url(requests_mock, service, profile):
+    service_response = {
+        "some": "json",
+    }
+
     service_connection = ServiceConnectionFactory(profile=profile, service=service)
     requests_mock.get(
         f"{GDPR_URL}{profile.pk}",
-        json=youth_profile_response,
+        json=service_response,
         request_headers={"authorization": "Bearer token"},
     )
 
     response = service_connection.download_gdpr_data(api_token="token")
-    assert response == youth_profile_response
+    assert response == service_response
 
 
 def test_download_gdpr_data_returns_empty_dict_if_no_url(

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ known_first_party=
     subscriptions,
     users,
     utils,
-    youths,
 
 [pydocstyle]
 ignore=D100,D104,D105,D200,D203,D400

--- a/utils/tests/test_commands.py
+++ b/utils/tests/test_commands.py
@@ -2,18 +2,17 @@ from django.contrib.auth.models import Group
 from django.core.management import call_command
 
 from profiles.models import Profile
-from services.enums import ServiceType
 from services.models import AllowedDataField, Service
 from subscriptions.models import SubscriptionType, SubscriptionTypeCategory
 from users.models import User
-from utils.utils import DATA_FIELD_VALUES
+from utils.utils import DATA_FIELD_VALUES, SERVICES
 
 
 def test_command_seed_data_works_without_arguments():
     call_command("seed_data")
 
-    assert Service.objects.count() == len(ServiceType)
-    assert Group.objects.count() == len(ServiceType)
+    assert Service.objects.count() == len(SERVICES)
+    assert Group.objects.count() == len(SERVICES)
     assert User.objects.filter(is_superuser=True).count() == 0
     assert AllowedDataField.objects.count() == len(DATA_FIELD_VALUES)
     assert SubscriptionType.objects.count() == 3
@@ -33,7 +32,7 @@ def test_command_seed_data_initializes_development_data():
     normal_users = 50
     assert (
         User.objects.count()
-        == normal_users + len(ServiceType) + admin_users + anonymous_users
+        == normal_users + len(SERVICES) + admin_users + anonymous_users
     )
     assert Profile.objects.count() == normal_users
     assert User.objects.filter(is_superuser=True).count() == admin_users

--- a/utils/tests/test_utils.py
+++ b/utils/tests/test_utils.py
@@ -72,9 +72,9 @@ def test_creates_random_user():
 def test_creates_defined_user():
     assert User.objects.count() == 1  # anonymous user exists
     faker = Faker()
-    user = create_user(username="berth_user", faker=faker)
+    user = create_user(username="test_user", faker=faker)
     assert User.objects.count() == 2
-    assert user.username == "berth_user"
+    assert user.username == "test_user"
 
 
 def test_create_user_returns_existing_user():

--- a/utils/tests/test_utils.py
+++ b/utils/tests/test_utils.py
@@ -6,7 +6,6 @@ from guardian.shortcuts import get_group_perms
 
 from open_city_profile.tests.factories import GroupFactory
 from profiles.models import Profile
-from services.enums import ServiceType
 from services.models import AllowedDataField, Service, ServiceConnection
 from users.models import User
 from utils.utils import (
@@ -19,6 +18,7 @@ from utils.utils import (
     generate_profiles,
     generate_service_connections,
     generate_services,
+    SERVICES,
 )
 
 
@@ -28,8 +28,8 @@ def test_generate_services(times):
     assert Service.objects.count() == 0
     for i in range(times):
         services = generate_services()
-    assert len(services) == len(ServiceType)
-    assert Service.objects.count() == len(ServiceType)
+    assert len(services) == len(SERVICES)
+    assert Service.objects.count() == len(SERVICES)
 
 
 @pytest.mark.parametrize("times", [1, 2])
@@ -86,7 +86,7 @@ def test_create_user_returns_existing_user():
 
 
 def test_generates_group_admins():
-    group = GroupFactory(name=ServiceType.BERTH.value)
+    group = GroupFactory(name="group_name")
     assert group.user_set.count() == 0
     generate_group_admins([group], faker=Faker())
     assert group.user_set.count() == 1


### PR DESCRIPTION
Searched for occurrences of the words "service_type", "berth" and "youth", in various forms. Tried to get rid of most of them.