### PR TITLE
Fix GraphQL error formatting

### DIFF
--- a/open_city_profile/views.py
+++ b/open_city_profile/views.py
@@ -69,6 +69,15 @@ sentry_ignored_errors = (
 error_codes = {**error_codes_shared, **error_codes_profile}
 
 
+def _get_error_code(exception):
+    """Get the most specific error code for the exception via superclass"""
+    for exception in exception.mro():
+        try:
+            return error_codes[exception]
+        except KeyError:
+            continue
+
+
 class GraphQLView(BaseGraphQLView):
     def execute_graphql_request(self, request, data, query, *args, **kwargs):
         """Extract any exceptions and send some of them to Sentry"""
@@ -99,23 +108,19 @@ class GraphQLView(BaseGraphQLView):
 
     @staticmethod
     def format_error(error):
-        def get_error_code(exception):
-            """Get the most specific error code for the exception via superclass"""
-            for exception in exception.mro():
-                try:
-                    return error_codes[exception]
-                except KeyError:
-                    continue
-
-        try:
-            error_code = get_error_code(error.original_error.__class__)
-        except AttributeError:
-            error_code = GENERAL_ERROR
         formatted_error = super(GraphQLView, GraphQLView).format_error(error)
-        if error_code and isinstance(formatted_error, dict):
-            if "extensions" not in formatted_error:
-                formatted_error["extensions"] = {}
 
-            if "code" not in formatted_error["extensions"]:
-                formatted_error["extensions"]["code"] = error_code
+        if isinstance(formatted_error, dict):
+            try:
+                error_code = _get_error_code(error.original_error.__class__)
+            except AttributeError:
+                error_code = GENERAL_ERROR
+
+            if error_code:
+                if "extensions" not in formatted_error:
+                    formatted_error["extensions"] = {}
+
+                if "code" not in formatted_error["extensions"]:
+                    formatted_error["extensions"]["code"] = error_code
+
         return formatted_error

--- a/open_city_profile/views.py
+++ b/open_city_profile/views.py
@@ -112,12 +112,10 @@ class GraphQLView(BaseGraphQLView):
         except AttributeError:
             error_code = GENERAL_ERROR
         formatted_error = super(GraphQLView, GraphQLView).format_error(error)
-        if error_code and (
-            isinstance(formatted_error, dict)
-            and not (
-                "extensions" in formatted_error
-                and "code" in formatted_error["extensions"]
-            )
-        ):
-            formatted_error["extensions"] = {"code": error_code}
+        if error_code and isinstance(formatted_error, dict):
+            if "extensions" not in formatted_error:
+                formatted_error["extensions"] = {}
+
+            if "code" not in formatted_error["extensions"]:
+                formatted_error["extensions"]["code"] = error_code
         return formatted_error


### PR DESCRIPTION
A small fix for how the GraphQL errors are formatted. The previous code replaced any pre-existing "extensions" in the error with `{"code": error_code}`. Now the pre-existing data is preserved, the "code" member is just added to it. Also restructured the code in another commit in order to make it "flow" better.