### PR TITLE
Validate top level verified personal information early in the GraphQL call

### DIFF
--- a/profiles/models.py
+++ b/profiles/models.py
@@ -17,7 +17,7 @@ from thesaurus.models import Concept
 from services.models import ServiceConnection
 from users.models import User
 from utils.fields import CallableHashKeyEncryptedSearchField, NullToEmptyValueMixin
-from utils.models import SerializableMixin, UUIDModel, ValidateOnSaveModel
+from utils.models import SerializableMixin, UUIDModel
 
 from .enums import (
     AddressType,
@@ -247,7 +247,7 @@ def get_national_identification_number_hash_key():
     return settings.SALT_NATIONAL_IDENTIFICATION_NUMBER
 
 
-class VerifiedPersonalInformation(ValidateOnSaveModel):
+class VerifiedPersonalInformation(models.Model):
     profile = models.OneToOneField(
         Profile, on_delete=models.CASCADE, related_name="verified_personal_information"
     )

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -775,14 +775,12 @@ class CreateProfileMutation(relay.ClientIDMutation):
 
 class VerifiedPersonalInformationAddressInput(graphene.InputObjectType):
     street_address = graphene.String(
-        description="Street address with possible house number etc. Max length 1024 characters."
+        description="Street address with possible house number etc. Max length 100 characters."
     )
     postal_code = graphene.String(
-        description="Postal code. Max length 1024 characters."
+        description="Finnish postal code, exactly five digits."
     )
-    post_office = graphene.String(
-        description="Post office. Max length 1024 characters."
-    )
+    post_office = graphene.String(description="Post office. Max length 100 characters.")
 
     @staticmethod
     def validate_street_address(value, info, **input):
@@ -799,15 +797,13 @@ class VerifiedPersonalInformationAddressInput(graphene.InputObjectType):
 
 class VerifiedPersonalInformationForeignAddressInput(graphene.InputObjectType):
     street_address = graphene.String(
-        description="Street address or whatever is the _first part_ of the address. Max length 1024 characters."
+        description="Street address or whatever is the _first part_ of the address. Max length 100 characters."
     )
     additional_address = graphene.String(
         description="Additional address information, perhaps town, county, state, country etc. "
-        "Max length 1024 characters."
+        "Max length 100 characters."
     )
-    country_code = graphene.String(
-        description="An ISO 3166-1 country code. Max length 3 characters."
-    )
+    country_code = graphene.String(description="An ISO 3166-1 country code.")
 
     @staticmethod
     def validate_street_address(value, info, **input):
@@ -832,21 +828,21 @@ class VerifiedPersonalInformationForeignAddressInput(graphene.InputObjectType):
 
 class VerifiedPersonalInformationInput(graphene.InputObjectType):
     first_name = graphene.String(
-        description="First name(s). Max length 1024 characters."
+        description="First name(s). Max length 100 characters."
     )
-    last_name = graphene.String(description="Last name. Max length 1024 characters.")
+    last_name = graphene.String(description="Last name. Max length 100 characters.")
     given_name = graphene.String(
-        description="The name the person is called with. Max length 1024 characters."
+        description="The name the person is called with. Max length 100 characters."
     )
     national_identification_number = graphene.String(
-        description="Can be social security number or other person identifier. Max length 1024 characters."
+        description="Finnish personal identity code."
     )
     email = graphene.String(description="Email. Max length 1024 characters.")
     municipality_of_residence = graphene.String(
-        description="Official municipality of residence in Finland as a free form text. Max length 1024 characters."
+        description="Official municipality of residence in Finland as a free form text. Max length 100 characters."
     )
     municipality_of_residence_number = graphene.String(
-        description="Official municipality of residence in Finland as an official number. Max length 4 characters."
+        description="Official municipality of residence in Finland as an official number, exactly three digits."
     )
     permanent_address = graphene.InputField(
         VerifiedPersonalInformationAddressInput,

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -861,6 +861,40 @@ class VerifiedPersonalInformationInput(graphene.InputObjectType):
         description="The temporary foreign (i.e. not in Finland) residency address.",
     )
 
+    @staticmethod
+    def validate_first_name(value, info, **input):
+        return model_field_validation(VerifiedPersonalInformation, "first_name", value)
+
+    @staticmethod
+    def validate_last_name(value, info, **input):
+        return model_field_validation(VerifiedPersonalInformation, "last_name", value)
+
+    @staticmethod
+    def validate_given_name(value, info, **input):
+        return model_field_validation(VerifiedPersonalInformation, "given_name", value)
+
+    @staticmethod
+    def validate_national_identification_number(value, info, **input):
+        return model_field_validation(
+            VerifiedPersonalInformation, "national_identification_number", value
+        )
+
+    @staticmethod
+    def validate_email(value, info, **input):
+        return model_field_validation(VerifiedPersonalInformation, "email", value)
+
+    @staticmethod
+    def validate_municipality_of_residence(value, info, **input):
+        return model_field_validation(
+            VerifiedPersonalInformation, "municipality_of_residence", value
+        )
+
+    @staticmethod
+    def validate_municipality_of_residence_number(value, info, **input):
+        return model_field_validation(
+            VerifiedPersonalInformation, "municipality_of_residence_number", value
+        )
+
 
 class EmailInput(graphene.InputObjectType):
     email = graphene.String(description="The email address.", required=True)

--- a/utils/models.py
+++ b/utils/models.py
@@ -126,12 +126,3 @@ class SerializableMixin(models.Model):
                 if self._resolve_field(self, field) is not None
             ],
         }
-
-
-class ValidateOnSaveModel(models.Model):
-    class Meta:
-        abstract = True
-
-    def save(self, *args, **kwargs):
-        self.full_clean()
-        return super().save(*args, **kwargs)

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -18,7 +18,11 @@ def _multi_validation_error_from_django_validation_error(django_error):
     errors = []
 
     for err in django_error.error_list:
-        msg = err.message % err.params
+        msg = str(err.message)
+        try:
+            msg = msg % err.params
+        except TypeError:
+            pass
         errors.append({"code": err.code, "message": msg})
 
     return MultiValidationError(errors)


### PR DESCRIPTION
This PR does for verified personal information top level data the same thing that #329 did for the VPI addresses: input data is validated even before the `mutate` method is entered. Also fixes documentation.