### PR TITLE
PV-177 turn AddressNode into an entity that can be extended by other services

### DIFF
--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -626,7 +626,7 @@ type VerifiedPersonalInformationNode {
 
 scalar _Any
 
-union _Entity = ProfileNode
+union _Entity = AddressNode | ProfileNode
 
 type _Service {
   sdl: String

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -359,6 +359,7 @@ class PhoneNode(ContactNode):
         interfaces = (relay.Node,)
 
 
+@key(fields="id")
 class AddressNode(ContactNode):
     address_type = AllowedAddressType()
 

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -376,6 +376,26 @@ class AddressNode(ContactNode):
         )
         interfaces = (relay.Node,)
 
+    @login_and_service_required
+    def __resolve_reference(self, info, **kwargs):
+        address = graphene.Node.get_node_from_global_id(
+            info, self.id, only_type=AddressNode
+        )
+        if not address:
+            return None
+
+        service = info.context.service
+        user = info.context.user
+
+        if service.has_connection_to_profile(address.profile) and (
+            user == address.profile.user or user.has_perm("can_view_profiles", service)
+        ):
+            return address
+        else:
+            raise PermissionDenied(
+                _("You do not have permission to perform this action.")
+            )
+
 
 class VerifiedPersonalInformationAddressNode(graphene.ObjectType):
     street_address = graphene.String(

--- a/profiles/tests/test_gql_federation.py
+++ b/profiles/tests/test_gql_federation.py
@@ -45,6 +45,14 @@ def test_profile_connection_schema_matches_federated_schema(anon_user_gql_client
     )
 
 
+def test_address_connection_schema_matches_federated_schema(anon_user_gql_client):
+    executed = anon_user_gql_client.execute(GRAPHQL_SDL_QUERY)
+    assert (
+        "type AddressNodeConnection {   pageInfo: PageInfo!   edges: [AddressNodeEdge]! }"
+        in executed["data"]["_service"]["sdl"]
+    )
+
+
 def _create_profile_and_variables(with_serviceconnection, service, user=None):
     profile = ProfileFactory(user=user)
     if with_serviceconnection:

--- a/profiles/tests/test_gql_federation.py
+++ b/profiles/tests/test_gql_federation.py
@@ -16,21 +16,13 @@ GRAPHQL_SDL_QUERY = """
 """
 
 
-PROFILE_ENTITY_QUERY = """
+ENTITY_QUERY = """
     query ($_representations: [_Any!]!) {
         _entities(representations: $_representations) {
             ... on ProfileNode {
                 id
                 firstName
             }
-        }
-    }
-"""
-
-
-ADDRESS_ENTITY_QUERY = """
-    query ($_representations: [_Any!]!) {
-        _entities(representations: $_representations) {
             ... on AddressNode {
                 id
                 address
@@ -106,9 +98,7 @@ def test_anonymous_user_can_not_resolve_profile_entity(
 ):
     profile, variables = _create_profile_and_variables(with_serviceconnection, service)
     executed = anon_user_gql_client.execute(
-        PROFILE_ENTITY_QUERY,
-        variables=variables,
-        service=service if with_service else None,
+        ENTITY_QUERY, variables=variables, service=service if with_service else None,
     )
 
     assert_match_error_code(executed, "PERMISSION_DENIED_ERROR")
@@ -127,9 +117,7 @@ def test_owner_can_resolve_profile_entity(
         "_entities": [{"id": profile._global_id, "firstName": profile.first_name}]
     }
     executed = user_gql_client.execute(
-        PROFILE_ENTITY_QUERY,
-        variables=variables,
-        service=service if with_service else None,
+        ENTITY_QUERY, variables=variables, service=service if with_service else None,
     )
 
     if with_service and with_serviceconnection:
@@ -149,9 +137,7 @@ def test_non_owner_user_can_not_resolve_profile_entity(
 ):
     profile, variables = _create_profile_and_variables(with_serviceconnection, service)
     executed = user_gql_client.execute(
-        PROFILE_ENTITY_QUERY,
-        variables=variables,
-        service=service if with_service else None,
+        ENTITY_QUERY, variables=variables, service=service if with_service else None,
     )
 
     if not with_service:
@@ -177,7 +163,7 @@ def test_staff_user_can_resolve_profile_entity(
         "_entities": [{"id": profile._global_id, "firstName": profile.first_name}]
     }
     executed = user_gql_client.execute(
-        PROFILE_ENTITY_QUERY, variables=variables, service=service,
+        ENTITY_QUERY, variables=variables, service=service,
     )
 
     if with_serviceconnection:
@@ -194,9 +180,7 @@ def test_anonymous_user_can_not_resolve_address_entity(
 ):
     address, variables = _create_address_and_variables(with_serviceconnection, service)
     executed = anon_user_gql_client.execute(
-        ADDRESS_ENTITY_QUERY,
-        variables=variables,
-        service=service if with_service else None,
+        ENTITY_QUERY, variables=variables, service=service if with_service else None,
     )
 
     assert_match_error_code(executed, "PERMISSION_DENIED_ERROR")
@@ -222,9 +206,7 @@ def test_owner_can_resolve_address_entity(
     }
 
     executed = user_gql_client.execute(
-        ADDRESS_ENTITY_QUERY,
-        variables=variables,
-        service=service if with_service else None,
+        ENTITY_QUERY, variables=variables, service=service if with_service else None,
     )
 
     if with_service and with_serviceconnection:
@@ -244,9 +226,7 @@ def test_non_owner_user_can_not_resolve_address_entity(
 ):
     address, variables = _create_address_and_variables(with_serviceconnection, service)
     executed = user_gql_client.execute(
-        ADDRESS_ENTITY_QUERY,
-        variables=variables,
-        service=service if with_service else None,
+        ENTITY_QUERY, variables=variables, service=service if with_service else None,
     )
 
     if not with_service:
@@ -278,7 +258,7 @@ def test_staff_user_can_resolve_address_entity(
         ]
     }
     executed = user_gql_client.execute(
-        ADDRESS_ENTITY_QUERY, variables=variables, service=service,
+        ENTITY_QUERY, variables=variables, service=service,
     )
 
     if with_serviceconnection:

--- a/profiles/tests/test_gql_federation.py
+++ b/profiles/tests/test_gql_federation.py
@@ -28,12 +28,12 @@ PROFILE_ENTITY_QUERY = """
 """
 
 
-def test_profile_node_exposes_key_for_federation_gateway(anon_user_gql_client):
+@pytest.mark.parametrize("schema_type", ["ProfileNode", "AddressNode"])
+def test_node_exposes_key_for_federation_gateway(schema_type, anon_user_gql_client):
     executed = anon_user_gql_client.execute(GRAPHQL_SDL_QUERY)
-    assert (
-        'type ProfileNode implements Node  @key(fields: "id")'
-        in executed["data"]["_service"]["sdl"]
-    )
+    type_definition = f'type {schema_type} implements Node  @key(fields: "id")'
+    sdl = executed["data"]["_service"]["sdl"]
+    assert type_definition in sdl
 
 
 def test_profile_connection_schema_matches_federated_schema(anon_user_gql_client):

--- a/profiles/tests/test_gql_federation.py
+++ b/profiles/tests/test_gql_federation.py
@@ -7,38 +7,13 @@ from profiles.schema import ProfileNode
 from profiles.tests.factories import ProfileFactory
 from services.tests.factories import ServiceConnectionFactory
 
-
-def test_profile_node_exposes_key_for_federation_gateway(anon_user_gql_client):
-    query = """
-        query {
-            _service {
-                sdl
-            }
+GRAPHQL_SDL_QUERY = """
+    query {
+        _service {
+            sdl
         }
-    """
-
-    executed = anon_user_gql_client.execute(query)
-    assert (
-        'type ProfileNode implements Node  @key(fields: "id")'
-        in executed["data"]["_service"]["sdl"]
-    )
-
-
-def test_profile_connection_schema_matches_federated_schema(anon_user_gql_client):
-    query = """
-        query {
-            _service {
-                sdl
-            }
-        }
-    """
-
-    executed = anon_user_gql_client.execute(query)
-    assert (
-        "type ProfileNodeConnection {   pageInfo: PageInfo!   "
-        "edges: [ProfileNodeEdge]!   count: Int!   totalCount: Int! }"
-        in executed["data"]["_service"]["sdl"]
-    )
+    }
+"""
 
 
 PROFILE_ENTITY_QUERY = """
@@ -51,6 +26,23 @@ PROFILE_ENTITY_QUERY = """
         }
     }
 """
+
+
+def test_profile_node_exposes_key_for_federation_gateway(anon_user_gql_client):
+    executed = anon_user_gql_client.execute(GRAPHQL_SDL_QUERY)
+    assert (
+        'type ProfileNode implements Node  @key(fields: "id")'
+        in executed["data"]["_service"]["sdl"]
+    )
+
+
+def test_profile_connection_schema_matches_federated_schema(anon_user_gql_client):
+    executed = anon_user_gql_client.execute(GRAPHQL_SDL_QUERY)
+    assert (
+        "type ProfileNodeConnection {   pageInfo: PageInfo!   "
+        "edges: [ProfileNodeEdge]!   count: Int!   totalCount: Int! }"
+        in executed["data"]["_service"]["sdl"]
+    )
 
 
 def _create_profile_and_variables(with_serviceconnection, service, user=None):


### PR DESCRIPTION
Hi!

We're building parking-permits and we're using open-city-profile behind a gateway.

I'd like to be able to extend `AddressNode` in our service and add fields that come from KMO service (like getting the coordinates of an address, which zone it is in, etc).

Because at the moment the `AddressNode` does not have a `@key` field, I cannot extend this type in our service.

This PR adds the `@key` field so I can extend it.