### PR TITLE
Allow setting primary email `verified` flag

### DIFF
--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -187,6 +187,7 @@ type DeleteMyProfileMutationPayload {
 
 input EmailInput {
   email: String!
+  verified: Boolean
 }
 
 type EmailNode implements Node {

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -458,7 +458,7 @@ class Email(Contact):
             profile=self.profile, primary=True,
         )
         if self.pk:
-            existing_primary_emails.exclude(pk=self.pk)
+            existing_primary_emails = existing_primary_emails.exclude(pk=self.pk)
         if existing_primary_emails.exists():
             raise ValidationError("Primary email already exists")
 

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1022,8 +1022,9 @@ class CreateOrUpdateUserProfileMutationBase:
 
         profile.emails.exclude(pk=email.pk).filter(primary=True).update(primary=False)
 
-        if not email.primary:
+        if not email.primary or email.verified is not verified:
             email.primary = True
+            email.verified = verified
             email.save()
 
     @staticmethod

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -903,6 +903,9 @@ class VerifiedPersonalInformationInput(graphene.InputObjectType):
 
 class EmailInput(graphene.InputObjectType):
     email = graphene.String(description="The email address.", required=True)
+    verified = graphene.Boolean(
+        description="Sets whether the primary email address has been verified. If not given, defaults to False."
+    )
 
 
 class ProfileWithVerifiedPersonalInformationInput(graphene.InputObjectType):
@@ -1010,9 +1013,11 @@ class CreateOrUpdateUserProfileMutationBase:
     @staticmethod
     def _handle_primary_email(profile, primary_email_input):
         email_address = primary_email_input["email"]
+        verified = primary_email_input.get("verified", False)
 
         email, email_created = profile.emails.get_or_create(
-            email=email_address, defaults={"email_type": EmailType.NONE}
+            email=email_address,
+            defaults={"email_type": EmailType.NONE, "verified": verified},
         )
 
         profile.emails.exclude(pk=email.pk).filter(primary=True).update(primary=False)

--- a/profiles/tests/test_gql_create_or_update_user_profile_mutation.py
+++ b/profiles/tests/test_gql_create_or_update_user_profile_mutation.py
@@ -347,13 +347,14 @@ def test_create_primary_email_for_an_existing_profile(verified, user_gql_client)
 
 
 @pytest.mark.parametrize("old_is_primary", (True, False))
-def test_existing_primary_email_remains_when_trying_to_set_the_same_email_as_a_primary_email(
-    old_is_primary, user_gql_client
+@pytest.mark.parametrize("verified", (None, False, True))
+def test_existing_primary_email_is_modified_when_trying_to_set_the_same_email_as_a_primary_email(
+    old_is_primary, verified, user_gql_client
 ):
     old_email = EmailFactory(email_type=EmailType.PERSONAL, primary=old_is_primary)
     user_id = old_email.profile.user.uuid
 
-    input_data = primary_email_input_data(user_id, old_email.email)
+    input_data = primary_email_input_data(user_id, old_email.email, verified=verified)
     profile = execute_successful_mutation(input_data, user_gql_client)
 
     assert profile.emails.count() == 1
@@ -361,6 +362,10 @@ def test_existing_primary_email_remains_when_trying_to_set_the_same_email_as_a_p
     assert email.email == old_email.email
     assert email.primary is True
     assert email.email_type == old_email.email_type
+    if verified is True:
+        assert email.verified is True
+    else:
+        assert email.verified is False
 
 
 @pytest.mark.parametrize(

--- a/profiles/tests/test_models.py
+++ b/profiles/tests/test_models.py
@@ -186,6 +186,12 @@ def test_should_not_allow_two_primary_emails(profile):
         EmailFactory(profile=profile, primary=True)
 
 
+def test_should_allow_changing_fields_of_an_existing_primary_email():
+    email = EmailFactory(primary=True)
+    email.verified = True
+    email.save()
+
+
 class ValidationTestBase:
     @staticmethod
     def passes_validation(instance):


### PR DESCRIPTION
Adds possibility to control the `verified` flag of the primary email with the `createOrUpdateUserProfile` mutation.