### PR TITLE
OIDC back channel logout endpoint

### DIFF
--- a/.sanitizerconfig
+++ b/.sanitizerconfig
@@ -79,6 +79,12 @@ strategy:
     ad_group_id: null
     group_id: null
     id: null
+  helusers_oidcbackchannellogoutevent:
+    created_at: null
+    id: null
+    iss: null
+    sid: null
+    sub: null
   mailer_dontsendentry:
     id: null
     to_address: "profile.email"

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -244,6 +244,8 @@ AUTHENTICATION_BACKENDS = [
     "guardian.backends.ObjectPermissionBackend",
 ]
 
+HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED = True
+
 # Profiles related settings
 
 CONTACT_METHODS = (("email", "Email"), ("sms", "SMS"))

--- a/open_city_profile/urls.py
+++ b/open_city_profile/urls.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpResponse
-from django.urls import path
+from django.urls import include, path
 from django.views.decorators.csrf import csrf_exempt
 
 from open_city_profile.views import GraphQLView
@@ -15,6 +15,7 @@ urlpatterns = [
             GraphQLView.as_view(graphiql=settings.ENABLE_GRAPHIQL or settings.DEBUG)
         ),
     ),
+    path("auth/", include("helusers.urls")),
 ]
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ django-enumfields
 django-environ
 django-filter
 django-guardian
-django-helusers>=0.6
+django-helusers>=0.7
 django-ilmoitin>=0.2.0
 django-import-export
 django-munigeo

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ django-filter==2.4.0
     # via -r requirements.in
 django-guardian==2.1.0
     # via -r requirements.in
-django-helusers==0.6.0
+django-helusers==0.7.0
     # via -r requirements.in
 django-ilmoitin==0.2.0
     # via -r requirements.in


### PR DESCRIPTION
Update required Django-helusers to version 0.7.0. It provides an [OIDC back channel logout](https://openid.net/specs/openid-connect-backchannel-1_0.html) endpoint implementation. That feature is taken into use with the `HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED` feature flag.