### PR TITLE
Keycloak admin client

### DIFF
--- a/utils/keycloak.py
+++ b/utils/keycloak.py
@@ -33,9 +33,9 @@ class KeycloakAdminClient:
                 "client_id": self._client_id,
                 "client_secret": self._client_secret,
             }
-            client_credentials = self._session.post(
-                token_endpoint_url, data=credentials_request
-            ).json()
+            result = self._session.post(token_endpoint_url, data=credentials_request)
+            result.raise_for_status()
+            client_credentials = result.json()
             access_token = client_credentials["access_token"]
 
             self._auth = BearerAuth(access_token)

--- a/utils/keycloak.py
+++ b/utils/keycloak.py
@@ -12,7 +12,7 @@ class KeycloakAdminClient:
 
         self._session = requests.Session()
 
-    def get_user(self, user_id):
+    def _get_auth(self):
         well_known_url = f"{self._server_url}/auth/realms/{self._realm_name}/.well-known/openid-configuration"
         well_known = self._session.get(well_known_url).json()
 
@@ -27,6 +27,21 @@ class KeycloakAdminClient:
         ).json()
         access_token = client_credentials["access_token"]
 
-        url = f"{self._server_url}/auth/admin/realms/{self._realm_name}/users/{user_id}"
+        return BearerAuth(access_token)
 
-        return self._session.get(url, auth=BearerAuth(access_token)).json()
+    def _single_user_url(self, user_id):
+        return (
+            f"{self._server_url}/auth/admin/realms/{self._realm_name}/users/{user_id}"
+        )
+
+    def get_user(self, user_id):
+        url = self._single_user_url(user_id)
+        auth = self._get_auth()
+
+        return self._session.get(url, auth=auth).json()
+
+    def update_user(self, user_id, update_data: dict):
+        url = self._single_user_url(user_id)
+        auth = self._get_auth()
+
+        self._session.put(url, auth=auth, json=update_data)

--- a/utils/keycloak.py
+++ b/utils/keycloak.py
@@ -72,6 +72,9 @@ class KeycloakAdminClient:
     def send_verify_email(self, user_id):
         url = self._single_user_url(user_id)
         url += f"/send-verify-email"
-        return self._session.put(
-            url, auth=self._get_auth(), params={"client_id": self._client_id}
+
+        return self._handle_request_with_auth(
+            lambda auth: self._session.put(
+                url, auth=auth, params={"client_id": self._client_id}
+            )
         )

--- a/utils/keycloak.py
+++ b/utils/keycloak.py
@@ -51,6 +51,7 @@ class KeycloakAdminClient:
         response = requester(self._get_auth())
         if response.status_code == 401:
             response = requester(self._get_auth(force_renew=True))
+        response.raise_for_status()
         return response
 
     def get_user(self, user_id):

--- a/utils/keycloak.py
+++ b/utils/keycloak.py
@@ -1,4 +1,5 @@
 import requests
+from django.utils.functional import cached_property
 
 from utils.auth import BearerAuth
 
@@ -11,23 +12,30 @@ class KeycloakAdminClient:
         self._client_secret = client_secret
 
         self._session = requests.Session()
+        self._auth = None
+
+    @cached_property
+    def _well_known(self):
+        well_known_url = f"{self._server_url}/auth/realms/{self._realm_name}/.well-known/openid-configuration"
+
+        return self._session.get(well_known_url).json()
 
     def _get_auth(self):
-        well_known_url = f"{self._server_url}/auth/realms/{self._realm_name}/.well-known/openid-configuration"
-        well_known = self._session.get(well_known_url).json()
+        if not self._auth:
+            token_endpoint_url = self._well_known["token_endpoint"]
+            credentials_request = {
+                "grant_type": "client_credentials",
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+            }
+            client_credentials = self._session.post(
+                token_endpoint_url, data=credentials_request
+            ).json()
+            access_token = client_credentials["access_token"]
 
-        token_endpoint_url = well_known["token_endpoint"]
-        credentials_request = {
-            "grant_type": "client_credentials",
-            "client_id": self._client_id,
-            "client_secret": self._client_secret,
-        }
-        client_credentials = self._session.post(
-            token_endpoint_url, data=credentials_request
-        ).json()
-        access_token = client_credentials["access_token"]
+            self._auth = BearerAuth(access_token)
 
-        return BearerAuth(access_token)
+        return self._auth
 
     def _single_user_url(self, user_id):
         return (

--- a/utils/keycloak.py
+++ b/utils/keycloak.py
@@ -1,0 +1,32 @@
+import requests
+
+from utils.auth import BearerAuth
+
+
+class KeycloakAdminClient:
+    def __init__(self, server_url, realm_name, client_id, client_secret):
+        self._server_url = server_url
+        self._realm_name = realm_name
+        self._client_id = client_id
+        self._client_secret = client_secret
+
+        self._session = requests.Session()
+
+    def get_user(self, user_id):
+        well_known_url = f"{self._server_url}/auth/realms/{self._realm_name}/.well-known/openid-configuration"
+        well_known = self._session.get(well_known_url).json()
+
+        token_endpoint_url = well_known["token_endpoint"]
+        credentials_request = {
+            "grant_type": "client_credentials",
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+        }
+        client_credentials = self._session.post(
+            token_endpoint_url, data=credentials_request
+        ).json()
+        access_token = client_credentials["access_token"]
+
+        url = f"{self._server_url}/auth/admin/realms/{self._realm_name}/users/{user_id}"
+
+        return self._session.get(url, auth=BearerAuth(access_token)).json()

--- a/utils/keycloak.py
+++ b/utils/keycloak.py
@@ -68,3 +68,10 @@ class KeycloakAdminClient:
         self._handle_request_with_auth(
             lambda auth: self._session.put(url, auth=auth, json=update_data)
         )
+
+    def send_verify_email(self, user_id):
+        url = self._single_user_url(user_id)
+        url += f"/send-verify-email"
+        return self._session.put(
+            url, auth=self._get_auth(), params={"client_id": self._client_id}
+        )

--- a/utils/keycloak.py
+++ b/utils/keycloak.py
@@ -18,7 +18,9 @@ class KeycloakAdminClient:
     def _well_known(self):
         well_known_url = f"{self._server_url}/auth/realms/{self._realm_name}/.well-known/openid-configuration"
 
-        return self._session.get(well_known_url).json()
+        result = self._session.get(well_known_url)
+        result.raise_for_status()
+        return result.json()
 
     def _get_auth(self, force_renew=False):
         if force_renew:

--- a/utils/tests/test_keycloak.py
+++ b/utils/tests/test_keycloak.py
@@ -122,6 +122,15 @@ def test_fetch_single_user_data(keycloak_client):
     assert received_user == user_data
 
 
+def test_raise_exception_when_can_not_fetch_user_data(keycloak_client):
+    setup_well_known()
+    setup_client_credentials()
+    setup_user_response(user_id, user_data, status_code=404)
+
+    with pytest.raises(requests.HTTPError):
+        keycloak_client.get_user(user_id)
+
+
 def test_update_single_user_data(keycloak_client):
     setup_well_known()
     setup_client_credentials()
@@ -130,6 +139,15 @@ def test_update_single_user_data(keycloak_client):
     keycloak_client.update_user(user_id, user_data)
 
     assert update_mock.call_count == 1
+
+
+def test_raise_exception_when_can_not_update_user_data(keycloak_client):
+    setup_well_known()
+    setup_client_credentials()
+    setup_update_user_response(user_id, user_data, status_code=501)
+
+    with pytest.raises(requests.HTTPError):
+        keycloak_client.update_user(user_id, user_data)
 
 
 def test_remember_and_reuse_access_token(keycloak_client):

--- a/utils/tests/test_keycloak.py
+++ b/utils/tests/test_keycloak.py
@@ -1,6 +1,7 @@
 import urllib
 
 import pytest
+import requests
 
 from utils.keycloak import KeycloakAdminClient
 
@@ -38,9 +39,10 @@ def keycloak_client():
     return KeycloakAdminClient(server_url, realm_name, client_id, client_secret)
 
 
-def setup_well_known():
+def setup_well_known(status_code=200):
     return req_mock.get(
         f"{server_url}/auth/realms/{realm_name}/.well-known/openid-configuration",
+        status_code=status_code,
         json={"token_endpoint": token_endpoint_url},
     )
 
@@ -90,6 +92,13 @@ def setup_update_user_response(
         additional_matcher=body_matcher,
         status_code=status_code,
     )
+
+
+def test_raise_exception_when_can_not_get_openid_configuration(keycloak_client):
+    setup_well_known(status_code=404)
+
+    with pytest.raises(requests.HTTPError):
+        keycloak_client.get_user(user_id)
 
 
 def test_fetch_single_user_data(keycloak_client):

--- a/utils/tests/test_keycloak.py
+++ b/utils/tests/test_keycloak.py
@@ -12,6 +12,7 @@ client_secret = "test-client-secret"
 
 token_endpoint_url = f"{server_url}/token-endpoint"
 access_token = "test-access-token"
+unaccepted_access_token = "unaccepted-access-token"
 
 req_mock = None
 
@@ -44,7 +45,7 @@ def setup_well_known():
     )
 
 
-def setup_client_credentials():
+def setup_client_credentials(response_access_tokens=None):
     def body_matcher(request):
         body = urllib.parse.parse_qs(request.text, strict_parsing=True)
         return body == {
@@ -53,33 +54,41 @@ def setup_client_credentials():
             "client_secret": [client_secret],
         }
 
+    if response_access_tokens is None:
+        response_access_tokens = [access_token]
+    responses = [{"json": {"access_token": token}} for token in response_access_tokens]
+
     return req_mock.post(
         token_endpoint_url,
+        responses,
         request_headers={"Content-Type": "application/x-www-form-urlencoded"},
         additional_matcher=body_matcher,
-        json={"access_token": access_token},
     )
 
 
-def setup_user_response(user_id, user_data):
+def setup_user_response(user_id, user_data, token=access_token, status_code=200):
     req_mock.get(
         f"{server_url}/auth/admin/realms/{realm_name}/users/{user_id}",
-        request_headers={"Authorization": f"Bearer {access_token}"},
+        request_headers={"Authorization": f"Bearer {token}"},
         json=user_data,
+        status_code=status_code,
     )
 
 
-def setup_update_user_response(user_id, update_data):
+def setup_update_user_response(
+    user_id, update_data, token=access_token, status_code=200
+):
     def body_matcher(request):
         return request.json() == update_data
 
     return req_mock.put(
         f"{server_url}/auth/admin/realms/{realm_name}/users/{user_id}",
         request_headers={
-            "Authorization": f"Bearer {access_token}",
+            "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         },
         additional_matcher=body_matcher,
+        status_code=status_code,
     )
 
 
@@ -115,3 +124,37 @@ def test_remember_and_reuse_access_token(keycloak_client):
 
     assert well_known_mock.call_count == 1
     assert client_credentials_mock.call_count == 1
+
+
+def test_renew_access_token_when_old_one_is_not_accepted_with_user_data_fetch(
+    keycloak_client,
+):
+    setup_well_known()
+    setup_client_credentials(
+        response_access_tokens=[unaccepted_access_token, access_token]
+    )
+    setup_user_response(
+        user_id, user_data, token=unaccepted_access_token, status_code=401
+    )
+    setup_user_response(user_id, user_data, token=access_token)
+
+    received_user = keycloak_client.get_user(user_id)
+
+    assert received_user == user_data
+
+
+def test_renew_access_token_when_old_one_is_not_accepted_with_user_update(
+    keycloak_client,
+):
+    setup_well_known()
+    setup_client_credentials(
+        response_access_tokens=[unaccepted_access_token, access_token]
+    )
+    setup_update_user_response(
+        user_id, user_data, token=unaccepted_access_token, status_code=401
+    )
+    success_mock = setup_update_user_response(user_id, user_data, token=access_token)
+
+    keycloak_client.update_user(user_id, user_data)
+
+    assert success_mock.call_count == 1

--- a/utils/tests/test_keycloak.py
+++ b/utils/tests/test_keycloak.py
@@ -1,0 +1,78 @@
+import urllib
+
+import pytest
+
+from utils.keycloak import KeycloakAdminClient
+
+server_url = "https://keycloak.example"
+realm_name = "test-realm"
+
+client_id = "test-client-id"
+client_secret = "test-client-secret"
+
+token_endpoint_url = f"{server_url}/token-endpoint"
+access_token = "test-access-token"
+
+req_mock = None
+
+
+@pytest.fixture(autouse=True)
+def global_requests_mock(requests_mock):
+    global req_mock
+    req_mock = requests_mock
+    yield requests_mock
+
+    req_mock = None
+
+
+@pytest.fixture
+def keycloak_client():
+    return KeycloakAdminClient(server_url, realm_name, client_id, client_secret)
+
+
+def setup_well_known():
+    req_mock.get(
+        f"{server_url}/auth/realms/{realm_name}/.well-known/openid-configuration",
+        json={"token_endpoint": token_endpoint_url},
+    )
+
+
+def setup_client_credentials():
+    def body_matcher(request):
+        body = urllib.parse.parse_qs(request.text, strict_parsing=True)
+        return body == {
+            "grant_type": ["client_credentials"],
+            "client_id": [client_id],
+            "client_secret": [client_secret],
+        }
+
+    req_mock.post(
+        token_endpoint_url,
+        request_headers={"Content-Type": "application/x-www-form-urlencoded"},
+        additional_matcher=body_matcher,
+        json={"access_token": access_token},
+    )
+
+
+def setup_user_response(user_id, user_data):
+    req_mock.get(
+        f"{server_url}/auth/admin/realms/{realm_name}/users/{user_id}",
+        request_headers={"Authorization": f"Bearer {access_token}"},
+        json=user_data,
+    )
+
+
+def test_fetch_single_user_data(keycloak_client):
+    setup_well_known()
+    setup_client_credentials()
+    user_id = "test-user-id"
+    user_data = {
+        "id": user_id,
+        "firstName": "John",
+        "lastName": "Smith",
+    }
+    setup_user_response(user_id, user_data)
+
+    received_user = keycloak_client.get_user(user_id)
+
+    assert received_user == user_data

--- a/utils/tests/test_keycloak.py
+++ b/utils/tests/test_keycloak.py
@@ -97,6 +97,13 @@ def setup_update_user_response(
     )
 
 
+def setup_send_verify_email_response(user_id):
+    return req_mock.put(
+        f"{server_url}/auth/admin/realms/{realm_name}/users/{user_id}/send-verify-email?client_id={client_id}",
+        request_headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+
 def test_raise_exception_when_can_not_get_openid_configuration(keycloak_client):
     setup_well_known(status_code=404)
 
@@ -148,6 +155,16 @@ def test_raise_exception_when_can_not_update_user_data(keycloak_client):
 
     with pytest.raises(requests.HTTPError):
         keycloak_client.update_user(user_id, user_data)
+
+
+def test_send_verify_email_to_user(keycloak_client):
+    setup_well_known()
+    setup_client_credentials()
+    send_email_mock = setup_send_verify_email_response(user_id)
+
+    keycloak_client.send_verify_email(user_id)
+
+    assert send_email_mock.call_count == 1
 
 
 def test_remember_and_reuse_access_token(keycloak_client):


### PR DESCRIPTION
A simple client that calls Keycloak's admin REST API. It only supports three end points:

- [Fetching data for a single user](https://www.keycloak.org/docs-api/15.0/rest-api/#_getuser)
- [Updating data of a single user](https://www.keycloak.org/docs-api/15.0/rest-api/#_updateuser)
- [Sending a verification email for a user](https://www.keycloak.org/docs-api/15.0/rest-api/#_sendverifyemail)

The authentication uses client credentials grant type, like explained in [this documentation](https://www.keycloak.org/docs/latest/server_development/#authenticate-with-a-service-account).