### PR TITLE
Mark changed email as not verified

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1455,7 +1455,7 @@ class Query(graphene.ObjectType):
     def resolve_profile(self, info, **kwargs):
         service = info.context.service
         return Profile.objects.filter(service_connections__service=service).get(
-            pk=relay.Node.from_global_id(kwargs["id"])[1]
+            pk=from_global_id(kwargs["id"])[1]
         )
 
     @login_and_service_required

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -1,50 +1,8 @@
 import threading
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
-from graphql_relay.node.node import from_global_id
-
-from open_city_profile.exceptions import InvalidEmailFormatError
 
 _thread_locals = threading.local()
-
-
-def create_nested(model, profile, data):
-    for add_input in filter(None, data):
-        item = model(profile=profile)
-        for field, value in add_input.items():
-            if field == "primary" and value is True:
-                model.objects.filter(profile=profile).update(primary=False)
-            setattr(item, field, value)
-        try:
-            item.save()
-        except ValidationError:
-            if model.__name__ == "Email":
-                raise InvalidEmailFormatError("Email must be in valid email format")
-            else:
-                raise
-
-
-def update_nested(model, profile, data):
-    for update_input in filter(None, data):
-        id = update_input.pop("id")
-        item = model.objects.get(profile=profile, pk=from_global_id(id)[1])
-        for field, value in update_input.items():
-            if field == "primary" and value is True:
-                model.objects.filter(profile=profile).update(primary=False)
-            setattr(item, field, value)
-        try:
-            item.save()
-        except ValidationError:
-            if model.__name__ == "Email":
-                raise InvalidEmailFormatError("Email must be in valid email format")
-            else:
-                raise
-
-
-def delete_nested(model, profile, data):
-    for remove_id in filter(None, data):
-        model.objects.get(profile=profile, pk=from_global_id(remove_id)[1]).delete()
 
 
 def set_current_request(request):


### PR DESCRIPTION
When an existing email address is changed via GraphQL, mark that `Email` object as not verified.