### PR TITLE
Remove VerifiedPersonalInformation email from GraphQL schema

### DIFF
--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -603,7 +603,6 @@ input VerifiedPersonalInformationInput {
   lastName: String
   givenName: String
   nationalIdentificationNumber: String
-  email: String
   municipalityOfResidence: String
   municipalityOfResidenceNumber: String
   permanentAddress: VerifiedPersonalInformationAddressInput
@@ -618,7 +617,6 @@ type VerifiedPersonalInformationNode {
   nationalIdentificationNumber: String!
   municipalityOfResidence: String!
   municipalityOfResidenceNumber: String!
-  email: String! @deprecated(reason: "No email is provided here. This field will be eventually removed.")
   permanentAddress: VerifiedPersonalInformationAddressNode
   temporaryAddress: VerifiedPersonalInformationAddressNode
   permanentForeignAddress: VerifiedPersonalInformationForeignAddressNode

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -487,11 +487,6 @@ class VerifiedPersonalInformationNode(DjangoObjectType):
     # and you can't change it.
     national_identification_number = graphene.NonNull(graphene.String)
 
-    email = graphene.NonNull(
-        graphene.String,
-        deprecation_reason="No email is provided here. This field will be eventually removed.",
-    )
-
     permanent_address = graphene.Field(
         VerifiedPersonalInformationAddressNode,
         description="The permanent residency address in Finland.",
@@ -506,9 +501,6 @@ class VerifiedPersonalInformationNode(DjangoObjectType):
         VerifiedPersonalInformationForeignAddressNode,
         description="The temporary foreign (i.e. not in Finland) residency address.",
     )
-
-    def resolve_email(self, info, **kwargs):
-        return ""
 
     def resolve_permanent_address(self, info, **kwargs):
         try:
@@ -928,9 +920,6 @@ class VerifiedPersonalInformationInput(graphene.InputObjectType):
     national_identification_number = graphene.String(
         description="Finnish personal identity code."
     )
-    email = graphene.String(
-        description="**DEPRECATED**. This field is non-functional. It will be eventually removed."
-    )
     municipality_of_residence = graphene.String(
         description="Official municipality of residence in Finland as a free form text. Max length 100 characters."
     )
@@ -1073,7 +1062,6 @@ class CreateOrUpdateUserProfileMutationBase:
                 address_type["name"], None
             )
 
-        verified_personal_information_input.pop("email", None)
         vpi, created = VerifiedPersonalInformation.objects.update_or_create(
             profile=profile, defaults=verified_personal_information_input
         )

--- a/profiles/tests/test_gql_create_or_update_profile_with_verified_personal_information_mutation.py
+++ b/profiles/tests/test_gql_create_or_update_profile_with_verified_personal_information_mutation.py
@@ -59,7 +59,6 @@ def generate_input_data(user_id, overrides={}):
         "lastName": "Smith",
         "givenName": "Johnny",
         "nationalIdentificationNumber": "220202A1234",
-        "email": "john.smith@domain.example",
         "municipalityOfResidence": "Helsinki",
         "municipalityOfResidenceNumber": "091",
         "permanentAddress": {
@@ -169,7 +168,6 @@ def test_all_basic_fields_can_be_set_to_null(user_gql_client):
                 "lastName": None,
                 "givenName": None,
                 "nationalIdentificationNumber": None,
-                "email": None,
                 "municipalityOfResidence": None,
                 "municipalityOfResidenceNumber": None,
             },

--- a/profiles/tests/test_gql_create_or_update_user_profile_mutation.py
+++ b/profiles/tests/test_gql_create_or_update_user_profile_mutation.py
@@ -59,7 +59,6 @@ def generate_input_data(user_id, overrides={}):
         "lastName": "Smith VPI",
         "givenName": "Johnny",
         "nationalIdentificationNumber": "220202A1234",
-        "email": "john.smith@domain.example",
         "municipalityOfResidence": "Helsinki",
         "municipalityOfResidenceNumber": "091",
         "permanentAddress": {
@@ -176,7 +175,6 @@ def test_all_basic_fields_can_be_set_to_null(user_gql_client):
                 "lastName": None,
                 "givenName": None,
                 "nationalIdentificationNumber": None,
-                "email": None,
                 "municipalityOfResidence": None,
                 "municipalityOfResidenceNumber": None,
             },

--- a/profiles/tests/test_gql_my_profile_query.py
+++ b/profiles/tests/test_gql_my_profile_query.py
@@ -197,7 +197,6 @@ class TestProfileWithVerifiedPersonalInformation:
                     lastName
                     givenName
                     nationalIdentificationNumber
-                    email
                     municipalityOfResidence
                     municipalityOfResidenceNumber
                     permanentAddress {
@@ -260,7 +259,6 @@ class TestProfileWithVerifiedPersonalInformation:
                     "lastName": verified_personal_information.last_name,
                     "givenName": verified_personal_information.given_name,
                     "nationalIdentificationNumber": verified_personal_information.national_identification_number,
-                    "email": "",
                     "municipalityOfResidence": verified_personal_information.municipality_of_residence,
                     "municipalityOfResidenceNumber": verified_personal_information.municipality_of_residence_number,
                     "permanentAddress": {


### PR DESCRIPTION
The `VerifiedPersonalInformation` `email` field was already obsolete and completely non-functional. Now it's time to finally remove it.