### PR TITLE
Validate phone number input in GraphQL

### DIFF
--- a/open_city_profile/tests/conftest.py
+++ b/open_city_profile/tests/conftest.py
@@ -154,3 +154,8 @@ def get_unix_timestamp_now():
 @pytest.fixture
 def unix_timestamp_now():
     return get_unix_timestamp_now()
+
+
+@pytest.fixture(params=[None, ""])
+def empty_string_value(request):
+    return request.param

--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -251,7 +251,7 @@ type PageInfo {
 type PhoneNode implements Node {
   primary: Boolean!
   id: ID!
-  phone: String
+  phone: String!
   phoneType: PhoneType
 }
 

--- a/profiles/migrations/0048_change_phone_number_to_not_null.py
+++ b/profiles/migrations/0048_change_phone_number_to_not_null.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+def delete_null_phones(apps, schema_editor):
+    Phone = apps.get_model("profiles", "Phone")
+    Phone.objects.filter(phone=None).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("profiles", "0047_remove_verifiedpersonalinformation_email"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            delete_null_phones, reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="phone",
+            name="phone",
+            field=models.CharField(db_index=True, default="-", max_length=255),
+            preserve_default=False,
+        ),
+    ]

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -418,7 +418,7 @@ class Phone(Contact):
     profile = models.ForeignKey(
         Profile, related_name="phones", on_delete=models.CASCADE
     )
-    phone = models.CharField(max_length=255, null=True, blank=False, db_index=True)
+    phone = models.CharField(max_length=255, null=False, blank=False, db_index=True)
     phone_type = EnumField(
         PhoneType, max_length=32, blank=False, default=PhoneType.MOBILE
     )

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -836,7 +836,7 @@ class CreateProfileMutation(relay.ClientIDMutation):
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
         service = info.context.service
-        profile_data = input.pop("profile")
+        profile_data = input.get("profile")
         sensitivedata = profile_data.pop("sensitivedata", None)
 
         if sensitivedata and not info.context.user.has_perm(
@@ -845,6 +845,8 @@ class CreateProfileMutation(relay.ClientIDMutation):
             raise PermissionDenied(
                 _("You do not have permission to perform this action.")
             )
+
+        validate(cls, root, info, **input)
 
         nested_to_create = [
             (Email, profile_data.pop("add_emails", [])),

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1273,6 +1273,8 @@ class UpdateProfileMutation(relay.ClientIDMutation):
                 _("You do not have permission to perform this action.")
             )
 
+        validate(cls, root, info, **input)
+
         update_profile(profile, profile_data)
 
         if sensitive_data:

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -696,8 +696,12 @@ class CreatePhoneInput(graphene.InputObjectType):
 class UpdatePhoneInput(graphene.InputObjectType):
     primary = graphene.Boolean(description="Is this primary phone number.")
     id = graphene.ID(required=True)
-    phone = graphene.String(description="Phone number.")
+    phone = graphene.String(description="Phone number. If provided, must not be empty.")
     phone_type = AllowedPhoneType(description="Phone number type.")
+
+    @staticmethod
+    def validate_phone(value, info, **input):
+        return model_field_validation(Phone, "phone", value)
 
 
 class AddressInput(graphene.InputObjectType):

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1294,6 +1294,8 @@ class ClaimProfileMutation(relay.ClientIDMutation):
     @login_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
+        validate(cls, root, info, **input)
+
         profile_to_claim = get_claimable_profile(token=input["token"])
         if Profile.objects.filter(user=info.context.user).exists():
             # Logged in user has a profile

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1198,6 +1198,8 @@ class UpdateMyProfileMutation(relay.ClientIDMutation):
                 _("You do not have permission to perform this action.")
             )
 
+        validate(cls, root, info, **input)
+
         profile_data = input.pop("profile")
         sensitive_data = profile_data.pop("sensitivedata", None)
         subscription_data = profile_data.pop("subscriptions", [])

--- a/profiles/tests/profile_input_validation.py
+++ b/profiles/tests/profile_input_validation.py
@@ -1,0 +1,25 @@
+from open_city_profile.tests.asserts import assert_match_error_code
+
+
+class ProfileInputValidationBase:
+    def execute_query(self, user_gql_client, profile_input):
+        """This method needs to be implemented by sub classes.
+
+        Executes the GraphQL query, perhaps with something like
+        user_gql_client(query, variables={"profile_input": profile_input}),
+        and returns the result. The implementation specifies the used query
+        and can also provide extra input to the query as needed."""
+        raise NotImplementedError(
+            "execute_query needs to be implemented in a sub class."
+        )
+
+    def test_adding_phone_with_empty_phone_number_causes_a_validation_error(
+        self, user_gql_client, phone_data
+    ):
+        profile_input = {
+            "addPhones": [{"phone": "", "phoneType": phone_data["phone_type"]}],
+        }
+
+        executed = self.execute_query(user_gql_client, profile_input)
+
+        assert_match_error_code(executed, "VALIDATION_ERROR")

--- a/profiles/tests/test_gql_claim_profile_mutation.py
+++ b/profiles/tests/test_gql_claim_profile_mutation.py
@@ -14,7 +14,7 @@ from .factories import (
     ProfileFactory,
     ProfileWithPrimaryEmailFactory,
 )
-from .profile_input_validation import ProfileInputValidationBase
+from .profile_input_validation import ExistingProfileInputValidationBase
 
 
 def test_user_can_claim_claimable_profile_without_existing_profile(
@@ -167,10 +167,12 @@ def test_changing_an_email_address_marks_it_unverified(user_gql_client):
     assert executed["data"] == expected_data
 
 
-class TestProfileInputValidation(ProfileInputValidationBase):
+class TestProfileInputValidation(ExistingProfileInputValidationBase):
+    def create_profile(self, user):
+        return ProfileFactory(user=None)
+
     def execute_query(self, user_gql_client, profile_input):
-        profile = ProfileFactory(user=None)
-        claim_token = ClaimTokenFactory(profile=profile)
+        claim_token = ClaimTokenFactory(profile=self.profile)
 
         variables = {
             "token": str(claim_token.token),

--- a/profiles/tests/test_gql_claim_profile_mutation.py
+++ b/profiles/tests/test_gql_claim_profile_mutation.py
@@ -14,6 +14,7 @@ from .factories import (
     ProfileFactory,
     ProfileWithPrimaryEmailFactory,
 )
+from .profile_input_validation import ProfileInputValidationBase
 
 
 def test_user_can_claim_claimable_profile_without_existing_profile(
@@ -164,6 +165,19 @@ def test_changing_an_email_address_marks_it_unverified(user_gql_client):
 
     executed = user_gql_client.execute(CLAIM_PROFILE_MUTATION, variables=variables)
     assert executed["data"] == expected_data
+
+
+class TestProfileInputValidation(ProfileInputValidationBase):
+    def execute_query(self, user_gql_client, profile_input):
+        profile = ProfileFactory(user=None)
+        claim_token = ClaimTokenFactory(profile=profile)
+
+        variables = {
+            "token": str(claim_token.token),
+            "profileInput": profile_input,
+        }
+
+        return user_gql_client.execute(CLAIM_PROFILE_MUTATION, variables=variables)
 
 
 def test_user_cannot_claim_claimable_profile_if_token_expired(user_gql_client):

--- a/profiles/tests/test_gql_create_my_profile_mutation.py
+++ b/profiles/tests/test_gql_create_my_profile_mutation.py
@@ -4,6 +4,8 @@ import pytest
 
 from open_city_profile.tests.asserts import assert_match_error_code
 
+from .profile_input_validation import ProfileInputValidationBase
+
 
 @pytest.mark.parametrize("email_is_primary", [True, False])
 def test_normal_user_can_create_profile(
@@ -98,6 +100,27 @@ def test_normal_user_can_create_profile_with_no_email(user_gql_client, email_dat
 
     executed = user_gql_client.execute(mutation)
     assert executed["data"] == expected_data
+
+
+class TestProfileInputValidation(ProfileInputValidationBase):
+    def execute_query(self, user_gql_client, profile_input):
+        mutation = """
+            mutation createMyProfile($profileInput: ProfileInput!) {
+                createMyProfile(
+                    input: {
+                        profile: $profileInput
+                    }
+                ) {
+                    profile {
+                        id
+                    }
+                }
+            }
+        """
+
+        variables = {"profileInput": profile_input}
+
+        return user_gql_client.execute(mutation, variables=variables)
 
 
 def test_anon_user_can_not_create_profile(anon_user_gql_client):

--- a/profiles/tests/test_gql_update_my_profile_mutation.py
+++ b/profiles/tests/test_gql_update_my_profile_mutation.py
@@ -6,6 +6,7 @@ from graphql_relay.node.node import to_global_id
 from open_city_profile.consts import INVALID_EMAIL_FORMAT_ERROR
 from open_city_profile.tests.asserts import assert_match_error_code
 from profiles.models import Email, Profile
+from profiles.tests.profile_input_validation import ProfileInputValidationBase
 from services.tests.factories import ServiceConnectionFactory
 from subscriptions.tests.factories import (
     SubscriptionTypeCategoryFactory,
@@ -728,6 +729,15 @@ def test_remove_phone(user_gql_client):
         },
     )
     assert dict(executed["data"]) == expected_data
+
+
+class TestProfileInputValidation(ProfileInputValidationBase):
+    def execute_query(self, user_gql_client, profile_input):
+        ProfileFactory(user=user_gql_client.user)
+
+        return user_gql_client.execute(
+            PHONES_MUTATION, variables={"profileInput": profile_input},
+        )
 
 
 def test_add_address(user_gql_client, address_data):

--- a/profiles/tests/test_gql_update_my_profile_mutation.py
+++ b/profiles/tests/test_gql_update_my_profile_mutation.py
@@ -6,7 +6,7 @@ from graphql_relay.node.node import to_global_id
 from open_city_profile.consts import INVALID_EMAIL_FORMAT_ERROR
 from open_city_profile.tests.asserts import assert_match_error_code
 from profiles.models import Email, Profile
-from profiles.tests.profile_input_validation import ProfileInputValidationBase
+from profiles.tests.profile_input_validation import ExistingProfileInputValidationBase
 from services.tests.factories import ServiceConnectionFactory
 from subscriptions.tests.factories import (
     SubscriptionTypeCategoryFactory,
@@ -731,10 +731,11 @@ def test_remove_phone(user_gql_client):
     assert dict(executed["data"]) == expected_data
 
 
-class TestProfileInputValidation(ProfileInputValidationBase):
-    def execute_query(self, user_gql_client, profile_input):
-        ProfileFactory(user=user_gql_client.user)
+class TestProfileInputValidation(ExistingProfileInputValidationBase):
+    def create_profile(self, user):
+        return ProfileFactory(user=user)
 
+    def execute_query(self, user_gql_client, profile_input):
         return user_gql_client.execute(
             PHONES_MUTATION, variables={"profileInput": profile_input},
         )

--- a/profiles/tests/test_gql_update_profile_mutation.py
+++ b/profiles/tests/test_gql_update_profile_mutation.py
@@ -17,7 +17,7 @@ from .factories import (
     PhoneFactory,
     ProfileWithPrimaryEmailFactory,
 )
-from .profile_input_validation import ProfileInputValidationBase
+from .profile_input_validation import ExistingProfileInputValidationBase
 
 
 def setup_profile_and_staff_user_to_service(
@@ -280,14 +280,18 @@ def test_changing_an_email_address_marks_it_unverified(user_gql_client, service)
     assert executed["data"] == expected_data
 
 
-class TestProfileInputValidation(ProfileInputValidationBase):
+class TestProfileInputValidation(ExistingProfileInputValidationBase):
+    def create_profile(self, user):
+        return ProfileWithPrimaryEmailFactory()
+
     def execute_query(self, user_gql_client, profile_input):
-        profile = ProfileWithPrimaryEmailFactory()
         service = ServiceFactory()
 
-        setup_profile_and_staff_user_to_service(profile, user_gql_client.user, service)
+        setup_profile_and_staff_user_to_service(
+            self.profile, user_gql_client.user, service
+        )
 
-        profile_input["id"] = to_global_id("ProfileNode", profile.id)
+        profile_input["id"] = to_global_id("ProfileNode", self.profile.id)
         variables = {"profileInput": profile_input}
 
         return user_gql_client.execute(

--- a/profiles/tests/test_migrations.py
+++ b/profiles/tests/test_migrations.py
@@ -146,3 +146,36 @@ def test_verified_personal_information_searchable_national_identification_number
         create_data,
         verify_migration,
     )
+
+
+def test_phone_number_to_not_null_migration(migration_test_db):
+    NUM_PROFILES = 2
+    PHONE_NUMBER_LENGTH = 7
+
+    def create_data(apps):
+        Profile = apps.get_model(app, "Profile")
+        Phone = apps.get_model(app, "Phone")
+
+        for i in range(NUM_PROFILES):
+            profile = Profile.objects.create(first_name=str(i))
+            Phone.objects.create(profile=profile, phone=str(i) * PHONE_NUMBER_LENGTH)
+            Phone.objects.create(profile=profile, phone=None)
+
+    def verify_migration(apps):
+        Profile = apps.get_model(app, "Profile")
+        Phone = apps.get_model(app, "Phone")
+
+        assert Phone.objects.count() == NUM_PROFILES
+
+        for i in range(NUM_PROFILES):
+            profile = Profile.objects.get(first_name=str(i))
+            assert profile.phones.count() == 1
+            good_phone = Phone.objects.get(profile=profile)
+            assert good_phone.phone == str(i) * PHONE_NUMBER_LENGTH
+
+    execute_migration_test(
+        "0047_remove_verifiedpersonalinformation_email",
+        "0048_change_phone_number_to_not_null",
+        create_data,
+        verify_migration,
+    )

--- a/profiles/tests/test_models.py
+++ b/profiles/tests/test_models.py
@@ -9,6 +9,7 @@ from django.test import override_settings
 from ..models import Email, Profile, TemporaryReadAccessToken
 from .factories import (
     EmailFactory,
+    PhoneFactory,
     SensitiveDataFactory,
     VerifiedPersonalInformationFactory,
 )
@@ -211,6 +212,23 @@ class ValidationTestBase:
 
         setattr(instance, field_name, "x" * (max_length + 1))
         self.fails_validation(instance)
+
+
+class TestPhoneValidation(ValidationTestBase):
+    def test_valid_phone_instance_passes_validation(self):
+        instance = PhoneFactory()
+        self.passes_validation(instance)
+
+    @pytest.mark.parametrize("phone_number", [None, ""])
+    def test_invalid_phone_number(self, phone_number):
+        instance = PhoneFactory()
+        instance.phone = phone_number
+        self.fails_validation(instance)
+
+    def test_phone_number_max_length(self):
+        instance = PhoneFactory()
+
+        self.execute_string_field_max_length_validation_test(instance, "phone", 255)
 
 
 class TestVerifiedPersonalInformationValidation(ValidationTestBase):

--- a/profiles/tests/test_models.py
+++ b/profiles/tests/test_models.py
@@ -193,27 +193,24 @@ def test_should_allow_changing_fields_of_an_existing_primary_email():
 
 
 class ValidationTestBase:
-    @staticmethod
-    def passes_validation(instance):
+    def passes_validation(self, instance):
         try:
             instance.full_clean()
         except ValidationError as err:
             assert err is None
 
-    @staticmethod
-    def fails_validation(instance):
+    def fails_validation(self, instance):
         with pytest.raises(ValidationError):
             instance.full_clean()
 
-    @staticmethod
     def execute_string_field_max_length_validation_test(
-        instance, field_name, max_length
+        self, instance, field_name, max_length
     ):
         setattr(instance, field_name, "x" * max_length)
-        ValidationTestBase.passes_validation(instance)
+        self.passes_validation(instance)
 
         setattr(instance, field_name, "x" * (max_length + 1))
-        ValidationTestBase.fails_validation(instance)
+        self.fails_validation(instance)
 
 
 class TestVerifiedPersonalInformationValidation(ValidationTestBase):
@@ -246,21 +243,21 @@ class TestVerifiedPersonalInformationValidation(ValidationTestBase):
         info = VerifiedPersonalInformationFactory()
         setattr(info, field_name, invalid_value)
 
-        ValidationTestBase.fails_validation(info)
+        self.fails_validation(info)
 
     @pytest.mark.parametrize("invalid_value", ["150977_5554"])
     def test_national_identification_number(self, invalid_value):
         info = VerifiedPersonalInformationFactory()
         info.national_identification_number = invalid_value
 
-        ValidationTestBase.fails_validation(info)
+        self.fails_validation(info)
 
     @pytest.mark.parametrize("invalid_value", ["12", "1234", "aaa"])
     def test_municipality_of_residence_number(self, invalid_value):
         info = VerifiedPersonalInformationFactory()
         info.municipality_of_residence_number = invalid_value
 
-        ValidationTestBase.fails_validation(info)
+        self.fails_validation(info)
 
 
 @pytest.mark.parametrize("address_type", ["permanent_address", "temporary_address"])
@@ -285,14 +282,14 @@ class TestVerifiedPersonalInformationAddressValidation(ValidationTestBase):
         address = getattr(VerifiedPersonalInformationFactory(), address_type)
         setattr(address, field_name, invalid_value)
 
-        ValidationTestBase.fails_validation(address)
+        self.fails_validation(address)
 
     @pytest.mark.parametrize("invalid_value", ["1234", "1234X", "123456"])
     def test_postal_code(self, address_type, invalid_value):
         address = getattr(VerifiedPersonalInformationFactory(), address_type)
         address.postal_code = invalid_value
 
-        ValidationTestBase.fails_validation(address)
+        self.fails_validation(address)
 
 
 class TestVerifiedPersonalInformationPermanentForeignAddressValidation(
@@ -316,14 +313,14 @@ class TestVerifiedPersonalInformationPermanentForeignAddressValidation(
         address = VerifiedPersonalInformationFactory().permanent_foreign_address
         setattr(address, field_name, invalid_value)
 
-        ValidationTestBase.fails_validation(address)
+        self.fails_validation(address)
 
     @pytest.mark.parametrize("invalid_country_code", ["Finland", "Suomi", "123"])
     def test_country_codes(self, invalid_country_code):
         address = VerifiedPersonalInformationFactory().permanent_foreign_address
         address.country_code = invalid_country_code
 
-        ValidationTestBase.fails_validation(address)
+        self.fails_validation(address)
 
 
 class TestTemporaryReadAccessTokenValidityDuration:


### PR DESCRIPTION
Changed `Phone` model so that its `phone` field can't be `null` any more.

Added validation for phone numbers to everywhere in the GraphQL operations where phone numbers can be touched.