### PR TITLE
Fix Mailer message data sanitation configuration

### DIFF
--- a/.sanitizerconfig
+++ b/.sanitizerconfig
@@ -91,13 +91,13 @@ strategy:
     when_added: null
   mailer_message:
     id: null
-    message_data: "constant.null"
+    message_data: "string.random"
     priority: null
     when_added: null
   mailer_messagelog:
     id: null
     log_message: null
-    message_data: "constant.null"
+    message_data: "string.random"
     message_id: null
     priority: null
     result: null


### PR DESCRIPTION
The `message_data` database column in tables `mailer_message` and `mailer_messagelog` is NOT NULL. Hence it can't be sanitised to NULL or the data can't be imported. Instead generate a random string of the same length as the original value.