### PR TITLE
Verified personal information amr claim check

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -30,7 +30,7 @@ The following environment variables can be used to affect some standard Django s
 - `EMAIL_URL`: Configures email for Django using https://django-environ.readthedocs.io/en/latest/#email-settings[Django-environ]. Default is "consolemail://".
 - `VAR_ROOT`: Provides a base path for the https://docs.djangoproject.com/en/2.2/ref/settings/#media-root[`MEDIA_ROOT`] and https://docs.djangoproject.com/en/2.2/ref/settings/#static-root[`STATIC_ROOT`] Django settings. `MEDIA_ROOT` will be set to `${VAR_ROOT}/media` and `STATIC_ROOT` to `${VAR_ROOT}/static`. If run with Docker (determined by checking that the project is in an `/app` directory), `VAR_ROOT` defaults to `/var`. Otherwise it defaults to a path called `var` under the project directory.
 
-== Authentication server(s)
+== Authentication and authorization
 
 This project uses https://github.com/City-of-Helsinki/django-helusers[Django-helusers] for doing authentication. The following environment variables correspond directly to Django-helusers settings:
 
@@ -38,10 +38,11 @@ This project uses https://github.com/City-of-Helsinki/django-helusers[Django-hel
 - `TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX`: Corresponds to `OIDC_API_TOKEN_AUTH. API_SCOPE_PREFIX`. Default is empty.
 - `TOKEN_AUTH_REQUIRE_SCOPE`: Corresponds to `OIDC_API_TOKEN_AUTH. REQUIRE_API_SCOPE_FOR_AUTHENTICATION`. Default is `False`.
 
-The following environment variables configure authentication in other ways:
+The following environment variables configure authentication or authorization in other ways:
 
 - `TOKEN_AUTH_AUTHSERVER_URL`: Sets the "main" authentication server's URL. The URL needs to be exactly what the authentication server reports as its `issuer` value. Default is empty.
 - `ADDITIONAL_AUTHSERVER_URLS`: Sets additional authentication server URLs as a list of strings. JWTs signed by these servers are accepted for authentication. The URLs need to be exactly what the authentication servers report as their `issuer` value. Default is empty list.
+- `VERIFIED_PERSONAL_INFORMATION_ACCESS_AMR_LIST`: Can be used to limit staff users access to verified personal information fields for only those that have authenticated using certain authentication method (Denoted by the "amr" claim in the authentication token). If empty, access is not limited. Default is empty list.
 
 It's possible to configure open-city-profile to communicate with a https://www.keycloak.org/[Keycloak] instance. User data gets synchronised into the Keycloak instance. The Keycloak instance can simultaneously act as an authentication server but it doesn't have to. All the following settings are needed — if any are missing, then the communication with Keycloak feature is disabled.
 

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -68,6 +68,7 @@ env = environ.Env(
     KEYCLOAK_REALM=(str, ""),
     KEYCLOAK_CLIENT_ID=(str, ""),
     KEYCLOAK_CLIENT_SECRET=(str, ""),
+    VERIFIED_PERSONAL_INFORMATION_ACCESS_AMR_LIST=(list, []),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -256,6 +257,12 @@ CONTACT_METHODS = (("email", "Email"), ("sms", "SMS"))
 
 TEMPORARY_PROFILE_READ_ACCESS_TOKEN_VALIDITY_MINUTES = env.int(
     "TEMPORARY_PROFILE_READ_ACCESS_TOKEN_VALIDITY_MINUTES"
+)
+
+# List of values of the amr claim that give the staff user access
+# to verified personal information. If empty, any amr value grants access.
+VERIFIED_PERSONAL_INFORMATION_ACCESS_AMR_LIST = env.list(
+    "VERIFIED_PERSONAL_INFORMATION_ACCESS_AMR_LIST"
 )
 
 # Django-parler

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -74,7 +74,7 @@ from .models import (
     VerifiedPersonalInformationPermanentForeignAddress,
     VerifiedPersonalInformationTemporaryAddress,
 )
-from .utils import requester_has_service_permission
+from .utils import requester_can_view_verified_personal_information
 
 User = get_user_model()
 
@@ -366,9 +366,7 @@ class ProfileFilter(FilterSet):
     def filter_by_name_icontains(self, queryset, name, value):
         name_filter = Q(**{f"{name}__icontains": value})
 
-        if requester_has_service_permission(
-            self.request, "can_view_verified_personal_information"
-        ):
+        if requester_can_view_verified_personal_information(self.request):
             name_filter |= Q(
                 **{f"verified_personal_information__{name}__icontains": value}
             )
@@ -376,9 +374,7 @@ class ProfileFilter(FilterSet):
         return queryset.filter(name_filter)
 
     def filter_by_nin_exact(self, queryset, name, value):
-        if requester_has_service_permission(
-            self.request, "can_view_verified_personal_information"
-        ):
+        if requester_can_view_verified_personal_information(self.request):
             return queryset.filter(
                 verified_personal_information__national_identification_number=value
             )
@@ -624,9 +620,7 @@ class ProfileNode(RestrictedProfileNode):
         loa = info.context.user_auth.data.get("loa")
         if (
             info.context.user == self.user and loa in ["substantial", "high"]
-        ) or requester_has_service_permission(
-            info.context, "can_view_verified_personal_information"
-        ):
+        ) or requester_can_view_verified_personal_information(info.context):
             try:
                 return self.verified_personal_information
             except VerifiedPersonalInformation.DoesNotExist:

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -67,3 +67,13 @@ def requester_has_service_permission(request, permission):
         request._service_permission_cache[cache_key] = result
 
     return result
+
+
+def requester_can_view_verified_personal_information(request):
+    return requester_has_service_permission(
+        request, "can_view_verified_personal_information"
+    ) and (
+        not settings.VERIFIED_PERSONAL_INFORMATION_ACCESS_AMR_LIST
+        or request.user_auth.data.get("amr")
+        in settings.VERIFIED_PERSONAL_INFORMATION_ACCESS_AMR_LIST
+    )


### PR DESCRIPTION
This new functionality is used to further secure the access to verified personal information.

"amr" (Authentication Methods Reference) claim is set by the OP to be the name of the authentication backend the user used to authenticate.

If the VERIFIED_PERSONAL_INFORMATION_ACCESS_AMR_LIST-setting is empty, any authentication method grants access.

Refs HP-593