### PR TITLE
Validate email input in GraphQL

### DIFF
--- a/open_city_profile/tests/__init__.py
+++ b/open_city_profile/tests/__init__.py
@@ -1,4 +1,7 @@
 import inflection
+import pytest
+
+pytest.register_assert_rewrite("open_city_profile.tests.asserts")
 
 
 def to_graphql_name(s):

--- a/open_city_profile/tests/asserts.py
+++ b/open_city_profile/tests/asserts.py
@@ -28,4 +28,9 @@ def assert_almost_equal(a, b, epsilon=None):
 
 
 def assert_match_error_code(response, error_code):
-    assert response["errors"][0].get("extensions").get("code") == error_code
+    assert "errors" in response
+    error = response["errors"][0]
+    assert "extensions" in error
+    extensions = error["extensions"]
+    assert "code" in extensions
+    assert extensions["code"] == error_code


### PR DESCRIPTION
The email address inputs were already validated before. Improved test coverage to cover all mutations that handle emails. Also refactored the implementation to do validation earlier in the request handling.