### PR TITLE
Improve profile serialization test coverage

### DIFF
--- a/profiles/tests/test_models.py
+++ b/profiles/tests/test_models.py
@@ -5,6 +5,8 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test import override_settings
 
+from services.tests.factories import ServiceConnectionFactory
+
 from ..models import Email, Profile, TemporaryReadAccessToken
 from .factories import (
     AddressFactory,
@@ -87,6 +89,10 @@ def test_serialize_profile(profile):
     address_1 = AddressFactory(profile=profile, primary=True)
     address_2 = AddressFactory(profile=profile, primary=False)
     sensitive_data = SensitiveDataFactory(profile=profile)
+    service_connection_created_at = "2021-10-04"
+    service_connection = ServiceConnectionFactory(
+        profile=profile, created_at=service_connection_created_at
+    )
 
     serialized_profile = children_lists_to_unordered(profile.serialize())
 
@@ -184,7 +190,24 @@ def test_serialize_profile(profile):
                         },
                     ],
                 },
-                {"key": "SERVICE_CONNECTIONS", "children": []},
+                {
+                    "key": "SERVICE_CONNECTIONS",
+                    "children": [
+                        {
+                            "key": "SERVICECONNECTION",
+                            "children": [
+                                {
+                                    "key": "SERVICE",
+                                    "value": service_connection.service.name,
+                                },
+                                {
+                                    "key": "CREATED_AT",
+                                    "value": service_connection_created_at,
+                                },
+                            ],
+                        }
+                    ],
+                },
                 {"key": "SUBSCRIPTIONS", "children": []},
             ],
         }

--- a/profiles/tests/test_models.py
+++ b/profiles/tests/test_models.py
@@ -82,6 +82,8 @@ def children_lists_to_unordered(obj):
 def test_serialize_profile(profile):
     email_1 = EmailFactory(profile=profile, primary=True)
     email_2 = EmailFactory(profile=profile, primary=False)
+    phone_1 = PhoneFactory(profile=profile, primary=True)
+    phone_2 = PhoneFactory(profile=profile, primary=False)
     sensitive_data = SensitiveDataFactory(profile=profile)
 
     serialized_profile = children_lists_to_unordered(profile.serialize())
@@ -120,7 +122,27 @@ def test_serialize_profile(profile):
                         },
                     ],
                 },
-                {"key": "PHONES", "children": []},
+                {
+                    "key": "PHONES",
+                    "children": [
+                        {
+                            "key": "PHONE",
+                            "children": [
+                                {"key": "PRIMARY", "value": phone_1.primary},
+                                {"key": "PHONE_TYPE", "value": phone_1.phone_type.name},
+                                {"key": "PHONE", "value": phone_1.phone},
+                            ],
+                        },
+                        {
+                            "key": "PHONE",
+                            "children": [
+                                {"key": "PRIMARY", "value": phone_2.primary},
+                                {"key": "PHONE_TYPE", "value": phone_2.phone_type.name},
+                                {"key": "PHONE", "value": phone_2.phone},
+                            ],
+                        },
+                    ],
+                },
                 {"key": "ADDRESSES", "children": []},
                 {"key": "SERVICE_CONNECTIONS", "children": []},
                 {"key": "SUBSCRIPTIONS", "children": []},

--- a/profiles/tests/test_models.py
+++ b/profiles/tests/test_models.py
@@ -84,6 +84,8 @@ def test_serialize_profile(profile):
     email_2 = EmailFactory(profile=profile, primary=False)
     phone_1 = PhoneFactory(profile=profile, primary=True)
     phone_2 = PhoneFactory(profile=profile, primary=False)
+    address_1 = AddressFactory(profile=profile, primary=True)
+    address_2 = AddressFactory(profile=profile, primary=False)
     sensitive_data = SensitiveDataFactory(profile=profile)
 
     serialized_profile = children_lists_to_unordered(profile.serialize())
@@ -143,7 +145,45 @@ def test_serialize_profile(profile):
                         },
                     ],
                 },
-                {"key": "ADDRESSES", "children": []},
+                {
+                    "key": "ADDRESSES",
+                    "children": [
+                        {
+                            "key": "ADDRESS",
+                            "children": [
+                                {"key": "PRIMARY", "value": address_1.primary},
+                                {
+                                    "key": "ADDRESS_TYPE",
+                                    "value": address_1.address_type.name,
+                                },
+                                {"key": "ADDRESS", "value": address_1.address},
+                                {"key": "POSTAL_CODE", "value": address_1.postal_code},
+                                {"key": "CITY", "value": address_1.city},
+                                {
+                                    "key": "COUNTRY_CODE",
+                                    "value": address_1.country_code,
+                                },
+                            ],
+                        },
+                        {
+                            "key": "ADDRESS",
+                            "children": [
+                                {"key": "PRIMARY", "value": address_2.primary},
+                                {
+                                    "key": "ADDRESS_TYPE",
+                                    "value": address_2.address_type.name,
+                                },
+                                {"key": "ADDRESS", "value": address_2.address},
+                                {"key": "POSTAL_CODE", "value": address_2.postal_code},
+                                {"key": "CITY", "value": address_2.city},
+                                {
+                                    "key": "COUNTRY_CODE",
+                                    "value": address_2.country_code,
+                                },
+                            ],
+                        },
+                    ],
+                },
                 {"key": "SERVICE_CONNECTIONS", "children": []},
                 {"key": "SUBSCRIPTIONS", "children": []},
             ],

--- a/profiles/tests/test_models.py
+++ b/profiles/tests/test_models.py
@@ -80,8 +80,8 @@ def children_lists_to_unordered(obj):
 
 
 def test_serialize_profile(profile):
-    email_2 = EmailFactory(profile=profile)
-    email_1 = EmailFactory(profile=profile, primary=False)
+    email_1 = EmailFactory(profile=profile, primary=True)
+    email_2 = EmailFactory(profile=profile, primary=False)
     sensitive_data = SensitiveDataFactory(profile=profile)
 
     serialized_profile = children_lists_to_unordered(profile.serialize())


### PR DESCRIPTION
The `Profile` serialization output wasn't fully covered by tests. Increased that coverage. Didn't include `subscriptions` as it's an obsolete concept.