### PR TITLE
Stop using django-reversion

### DIFF
--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -202,7 +202,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "reversion.middleware.RevisionMiddleware",
     "open_city_profile.middleware.JWTAuthentication",
     "profiles.middleware.SetCurrentRequest",
 ]

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -10,7 +10,6 @@ from django.shortcuts import render
 from django.urls import path
 from django.utils.decorators import method_decorator
 from munigeo.models import AdministrativeDivision
-from reversion.admin import VersionAdmin
 
 from profiles.models import (
     Address,
@@ -169,7 +168,7 @@ class ImportProfilesFromJsonForm(forms.Form):
 
 
 @admin.register(Profile)
-class ExtendedProfileAdmin(VersionAdmin):
+class ExtendedProfileAdmin(admin.ModelAdmin):
     inlines = [
         VerifiedPersonalInformationAdminInline,
         SensitiveDataAdminInline,

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -3,7 +3,6 @@ import shutil
 import uuid
 from datetime import timedelta
 
-import reversion
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.storage import FileSystemStorage
@@ -57,7 +56,6 @@ class OverwriteStorage(FileSystemStorage):
         return name
 
 
-@reversion.register()
 class LegalRelationship(models.Model):
     representative = models.ForeignKey(  # "parent"
         "Profile", related_name="representatives", on_delete=models.CASCADE
@@ -82,7 +80,6 @@ class LegalRelationship(models.Model):
         return {"relationship": self}
 
 
-@reversion.register()
 class Profile(UUIDModel, SerializableMixin):
     user = models.OneToOneField(User, on_delete=models.PROTECT, null=True, blank=True)
     first_name = NullToEmptyCharField(max_length=255, blank=True, db_index=True)

--- a/users/admin.py
+++ b/users/admin.py
@@ -6,13 +6,12 @@ from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
-from reversion.admin import VersionAdmin
 
 User = get_user_model()
 
 
 @admin.register(User)
-class UserAdmin(VersionAdmin, DjangoUserAdmin):
+class UserAdmin(DjangoUserAdmin):
     list_display = (
         "uuid",
         "get_profile_uuid_link",

--- a/users/models.py
+++ b/users/models.py
@@ -1,7 +1,5 @@
-import reversion
 from helusers.models import AbstractUser
 
 
-@reversion.register()
 class User(AbstractUser):
     pass


### PR DESCRIPTION
There's no need to track object changes in this way any more. The reversion app is still in the `INSTALLED_APPS` so that the relevant database tables can be removed with a zero migration.