### PR TITLE
Update django to 2.2.25 and a few other dependency changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,7 @@ FROM appbase as development
 # ==============================
 
 COPY --chown=appuser:appuser requirements-dev.txt /app/requirements-dev.txt
-RUN pip install --no-cache-dir -r /app/requirements-dev.txt \
-    && pip install --no-cache-dir pip-tools
+RUN pip install --no-cache-dir -r /app/requirements-dev.txt
 
 ENV DEV_SERVER=1
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,7 @@ The project is now running at [localhost:8000](http://localhost:8000)
 
 This repository contains `requirements*.in` and corresponding `requirements*.txt` files for requirements handling. The `requirements*.txt` files are generated from the `requirements*.in` files with `pip-compile`.
 
-1. Install `pip-tools`:
-    * `pip install pip-tools`
-
-2. Add new packages to `requirements.in` or `requirements-dev.in`
+1. Add new packages to `requirements.in` or `requirements-dev.in`
 
 3. Update `.txt` file for the changed requirements file:
     * `pip-compile requirements.in`

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -9,6 +9,7 @@ ipython
 isort
 jedi
 pep8-naming
+pip-tools
 pre-commit
 pydocstyle
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,9 @@ cfgv==3.1.0
 chardet==3.0.4
     # via requests
 click==7.1.2
-    # via black
+    # via
+    #   black
+    #   pip-tools
 coverage==5.1
     # via pytest-cov
 decorator==4.4.2
@@ -104,6 +106,8 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pip-tools==5.5.0
+    # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
 pre-commit==2.3.0
@@ -206,4 +210,5 @@ zipp==3.1.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -10,7 +10,7 @@ faker==4.1.0
     # via factory-boy
 python-dateutil==2.8.1
     # via faker
-six==1.13.0
+six==1.14.0
     # via python-dateutil
 text-unidecode==1.3
     # via faker

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ django-searchable-encrypted-fields==0.1.3
     # via -r requirements.in
 django-thesaurus==0.0.2
     # via -r requirements.in
-django==2.2.24
+django==2.2.25
     # via
     #   -r requirements.in
     #   django-admin-sortable


### PR DESCRIPTION
Pip-tools has changed their dependency file format...again. Fixed the pip-tools version so that everybody knows what version should be used.

Updated Django, consolidated six versions.