### PR TITLE
Change usages of ugettext_lazy to gettext_lazy

### DIFF
--- a/open_city_profile/decorators.py
+++ b/open_city_profile/decorators.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from graphql.execution.base import ResolveInfo
 
 from open_city_profile.exceptions import ServiceNotIdentifiedError

--- a/profiles/enums.py
+++ b/profiles/enums.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from enumfields import Enum
 
 

--- a/services/enums.py
+++ b/services/enums.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from enumfields import Enum
 
 


### PR DESCRIPTION
The translation functions starting with 'u' are meant to be used for Python 2 compatibility. This project doesn't support Python 2. Also the 'u' prefixed functions will be removed in Django 4.0.