### PR TITLE
Deterministic and stable relay connections

### DIFF
--- a/profiles/models.py
+++ b/profiles/models.py
@@ -45,6 +45,9 @@ class Profile(UUIDModel, SerializableMixin):
         default=settings.CONTACT_METHODS[0][0],
     )
 
+    class Meta:
+        ordering = ["id"]
+
     serialize_fields = (
         {"name": "first_name"},
         {"name": "last_name"},

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -387,7 +387,7 @@ class Email(Contact):
     verified = models.BooleanField(default=False)
 
     class Meta:
-        ordering = ["-primary"]
+        ordering = ["-primary", "id"]
 
     serialize_fields = (
         {"name": "primary"},

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -359,6 +359,7 @@ class Contact(SerializableMixin):
 
     class Meta:
         abstract = True
+        ordering = ["-primary", "id"]
 
 
 class Phone(Contact):
@@ -385,9 +386,6 @@ class Email(Contact):
         EmailType, max_length=32, blank=False, default=EmailType.PERSONAL
     )
     verified = models.BooleanField(default=False)
-
-    class Meta:
-        ordering = ["-primary", "id"]
 
     serialize_fields = (
         {"name": "primary"},

--- a/profiles/tests/test_gql_relay_ordering.py
+++ b/profiles/tests/test_gql_relay_ordering.py
@@ -1,6 +1,10 @@
 from graphql_relay import from_global_id
 
-from services.tests.factories import ServiceConnectionFactory, ServiceFactory
+from services.tests.factories import (
+    AllowedDataFieldFactory,
+    ServiceConnectionFactory,
+    ServiceFactory,
+)
 
 from .factories import AddressFactory, EmailFactory, PhoneFactory, ProfileFactory
 
@@ -32,6 +36,16 @@ QUERY = """
             edges {
                 node {
                     id
+                    service {
+                        allowedDataFields {
+                            edges {
+                                node {
+                                    fieldName
+                                    order
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -104,3 +118,33 @@ def test_service_connections_are_ordered_by_id(user_gql_client):
     assert len(connection_edges) == len(connections)
     for edge, connection in zip(connection_edges, connections):
         assert from_global_id(edge["node"]["id"])[1] == str(connection.id)
+
+
+def test_allowed_data_fields_are_ordered_by_order_field(user_gql_client, service):
+    fields = (
+        AllowedDataFieldFactory(field_name="1: field 2", final_order=2),
+        AllowedDataFieldFactory(field_name="2: field 3", final_order=3),
+        AllowedDataFieldFactory(field_name="3: field 1", final_order=1),
+    )
+    service.allowed_data_fields.set(fields)
+
+    profile = ProfileFactory(user=user_gql_client.user)
+    ServiceConnectionFactory(profile=profile, service=service)
+
+    executed = user_gql_client.execute(QUERY)
+
+    connection_edges = executed["data"]["myProfile"]["serviceConnections"]["edges"]
+
+    assert len(connection_edges) == 1
+    service_node = connection_edges[0]["node"]["service"]
+    allowed_data_field_edges = service_node["allowedDataFields"]["edges"]
+
+    assert len(allowed_data_field_edges) == 3
+
+    fields_in_expected_order = sorted(fields, key=lambda x: x.order)
+    for allowed_data_field_edge, field in zip(
+        allowed_data_field_edges, fields_in_expected_order
+    ):
+        received_field = allowed_data_field_edge["node"]
+        assert received_field["fieldName"] == field.field_name
+        assert received_field["order"] == field.order

--- a/profiles/tests/test_gql_relay_ordering.py
+++ b/profiles/tests/test_gql_relay_ordering.py
@@ -1,4 +1,49 @@
-from .factories import EmailFactory, ProfileFactory
+from .factories import AddressFactory, EmailFactory, PhoneFactory, ProfileFactory
+
+QUERY = """
+{
+    myProfile {
+        addresses {
+            edges {
+                node {
+                    address
+                }
+            }
+        }
+        emails {
+            edges {
+                node {
+                    email
+                }
+            }
+        }
+        phones {
+            edges {
+                node {
+                    phone
+                }
+            }
+        }
+    }
+}
+"""
+
+
+def test_addresses_are_ordered_first_by_primary_then_by_id(user_gql_client):
+    profile = ProfileFactory(user=user_gql_client.user)
+    first_address = AddressFactory(profile=profile, primary=False)
+    primary_address = AddressFactory(profile=profile, primary=True)
+    second_address = AddressFactory(profile=profile, primary=False)
+
+    expected_edges = list(
+        map(
+            lambda address: {"node": {"address": address.address}},
+            (primary_address, first_address, second_address),
+        )
+    )
+
+    executed = user_gql_client.execute(QUERY)
+    assert executed["data"]["myProfile"]["addresses"]["edges"] == expected_edges
 
 
 def test_emails_are_ordered_first_by_primary_then_by_id(user_gql_client):
@@ -7,20 +52,6 @@ def test_emails_are_ordered_first_by_primary_then_by_id(user_gql_client):
     primary_email = EmailFactory(profile=profile, primary=True)
     second_email = EmailFactory(profile=profile, primary=False)
 
-    query = """
-        {
-            myProfile {
-                emails {
-                    edges {
-                        node {
-                            email
-                        }
-                    }
-                }
-            }
-        }
-    """
-
     expected_edges = list(
         map(
             lambda email: {"node": {"email": email.email}},
@@ -28,5 +59,22 @@ def test_emails_are_ordered_first_by_primary_then_by_id(user_gql_client):
         )
     )
 
-    executed = user_gql_client.execute(query)
+    executed = user_gql_client.execute(QUERY)
     assert executed["data"]["myProfile"]["emails"]["edges"] == expected_edges
+
+
+def test_phones_are_ordered_first_by_primary_then_by_id(user_gql_client):
+    profile = ProfileFactory(user=user_gql_client.user)
+    first_phone = PhoneFactory(profile=profile, primary=False)
+    primary_phone = PhoneFactory(profile=profile, primary=True)
+    second_phone = PhoneFactory(profile=profile, primary=False)
+
+    expected_edges = list(
+        map(
+            lambda phone: {"node": {"phone": phone.phone}},
+            (primary_phone, first_phone, second_phone),
+        )
+    )
+
+    executed = user_gql_client.execute(QUERY)
+    assert executed["data"]["myProfile"]["phones"]["edges"] == expected_edges

--- a/profiles/tests/test_gql_relay_ordering.py
+++ b/profiles/tests/test_gql_relay_ordering.py
@@ -1,0 +1,32 @@
+from .factories import EmailFactory, ProfileFactory
+
+
+def test_emails_are_ordered_first_by_primary_then_by_id(user_gql_client):
+    profile = ProfileFactory(user=user_gql_client.user)
+    first_email = EmailFactory(profile=profile, primary=False)
+    primary_email = EmailFactory(profile=profile, primary=True)
+    second_email = EmailFactory(profile=profile, primary=False)
+
+    query = """
+        {
+            myProfile {
+                emails {
+                    edges {
+                        node {
+                            email
+                        }
+                    }
+                }
+            }
+        }
+    """
+
+    expected_edges = list(
+        map(
+            lambda email: {"node": {"email": email.email}},
+            (primary_email, first_email, second_email),
+        )
+    )
+
+    executed = user_gql_client.execute(query)
+    assert executed["data"]["myProfile"]["emails"]["edges"] == expected_edges

--- a/services/models.py
+++ b/services/models.py
@@ -75,6 +75,7 @@ class Service(TranslatableModel):
                 name="unique_is_profile_service",
             )
         ]
+        ordering = ["id"]
         permissions = (
             ("can_manage_profiles", "Can manage profiles"),
             ("can_view_profiles", "Can view profiles"),

--- a/services/models.py
+++ b/services/models.py
@@ -147,6 +147,7 @@ class ServiceConnection(SerializableMixin):
 
     class Meta:
         unique_together = ("profile", "service")
+        ordering = ["id"]
 
     def __str__(self):
         return "{} {} - {}".format(

--- a/services/tests/factories.py
+++ b/services/tests/factories.py
@@ -52,5 +52,10 @@ class AllowedDataFieldFactory(factory.django.DjangoModelFactory):
     field_name = factory.Sequence(lambda n: "name %d" % n)
     label = factory.Sequence(lambda n: "Label %d" % n)
 
+    @factory.post_generation
+    def final_order(self, create, extracted, **kwargs):
+        if extracted is not None:
+            self.order = extracted
+
     class Meta:
         model = AllowedDataField


### PR DESCRIPTION
For Relay pagination to work correctly, it's required that the order stays stable from request to another for the items that are paginated through. For example let's say capital letters of latin alphabets are the items. The requester requests 3 items at a time. One request could return

```json
{
    "letters": {
        "edges": [
            {
                "node": { "letter": "F" },
                "cursor": "ID_F"
            },
            {
                "node": { "letter": "G" },
                "cursor": "ID_G"
            },
            {
                "node": { "letter": "H" },
                "cursor": "ID_H"
            }
        ]
    }
}
```

The next request could be for the next page:

```graphql
query {
    letters(first: 3, after: "ID_H") {
        ...
    }
}
```

It would be quite wrong if this request returned anything else than the letters I, J and K. But for that to be the case, there needs to be a deterministic order for the items. For letters it's the alphabetical order. For other types of items it may be necessary to specify the ordering logic. That's what is done in this PR.

All other GraphQL `*Connection` types are taken care of instead of those starting with `Subscription`. The Subscription concept is obsolete since #385 and the related connections just return empty results now.