### PR TITLE
Remove the hardcoded `/auth` context path from Keycloak client

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -46,7 +46,7 @@ The following environment variables configure authentication or authorization in
 
 It's possible to configure open-city-profile to communicate with a https://www.keycloak.org/[Keycloak] instance. User data gets synchronised into the Keycloak instance. The Keycloak instance can simultaneously act as an authentication server but it doesn't have to. All the following settings are needed — if any are missing, then the communication with Keycloak feature is disabled.
 
-- `KEYCLOAK_BASE_URL`: The base URL of the Keycloak server, without any path parts.
+- `KEYCLOAK_BASE_URL`: The base URL of the Keycloak server, including any configured context path.
 - `KEYCLOAK_REALM`: The name of the https://www.keycloak.org/docs/latest/server_admin/#the-master-realm[Keycloak realm] to use.
 - `KEYCLOAK_CLIENT_ID`: Authentication to the Keycloak instance happens https://www.keycloak.org/docs/latest/server_development/#authenticate-with-a-service-account[using a service account]. This is the client id.
 - `KEYCLOAK_CLIENT_SECRET`: ...and this is the client secret.

--- a/utils/keycloak.py
+++ b/utils/keycloak.py
@@ -16,7 +16,7 @@ class KeycloakAdminClient:
 
     @cached_property
     def _well_known(self):
-        well_known_url = f"{self._server_url}/auth/realms/{self._realm_name}/.well-known/openid-configuration"
+        well_known_url = f"{self._server_url}/realms/{self._realm_name}/.well-known/openid-configuration"
 
         result = self._session.get(well_known_url)
         result.raise_for_status()
@@ -43,9 +43,7 @@ class KeycloakAdminClient:
         return self._auth
 
     def _single_user_url(self, user_id):
-        return (
-            f"{self._server_url}/auth/admin/realms/{self._realm_name}/users/{user_id}"
-        )
+        return f"{self._server_url}/admin/realms/{self._realm_name}/users/{user_id}"
 
     def _handle_request_with_auth(self, requester):
         response = requester(self._get_auth())

--- a/utils/tests/test_keycloak.py
+++ b/utils/tests/test_keycloak.py
@@ -41,7 +41,7 @@ def keycloak_client():
 
 def setup_well_known(status_code=200):
     return req_mock.get(
-        f"{server_url}/auth/realms/{realm_name}/.well-known/openid-configuration",
+        f"{server_url}/realms/{realm_name}/.well-known/openid-configuration",
         status_code=status_code,
         json={"token_endpoint": token_endpoint_url},
     )
@@ -73,7 +73,7 @@ def setup_client_credentials(response_access_tokens=None, status_code=200):
 
 def setup_user_response(user_id, user_data, token=access_token, status_code=200):
     req_mock.get(
-        f"{server_url}/auth/admin/realms/{realm_name}/users/{user_id}",
+        f"{server_url}/admin/realms/{realm_name}/users/{user_id}",
         request_headers={"Authorization": f"Bearer {token}"},
         json=user_data,
         status_code=status_code,
@@ -87,7 +87,7 @@ def setup_update_user_response(
         return request.json() == update_data
 
     return req_mock.put(
-        f"{server_url}/auth/admin/realms/{realm_name}/users/{user_id}",
+        f"{server_url}/admin/realms/{realm_name}/users/{user_id}",
         request_headers={
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
@@ -99,7 +99,7 @@ def setup_update_user_response(
 
 def setup_delete_user_response(user_id, token=access_token, status_code=200):
     return req_mock.delete(
-        f"{server_url}/auth/admin/realms/{realm_name}/users/{user_id}",
+        f"{server_url}/admin/realms/{realm_name}/users/{user_id}",
         request_headers={"Authorization": f"Bearer {token}"},
         status_code=status_code,
     )
@@ -107,7 +107,7 @@ def setup_delete_user_response(user_id, token=access_token, status_code=200):
 
 def setup_send_verify_email_response(user_id, token=access_token, status_code=200):
     return req_mock.put(
-        f"{server_url}/auth/admin/realms/{realm_name}/users/{user_id}/send-verify-email?client_id={client_id}",
+        f"{server_url}/admin/realms/{realm_name}/users/{user_id}/send-verify-email?client_id={client_id}",
         request_headers={"Authorization": f"Bearer {token}"},
         status_code=status_code,
     )


### PR DESCRIPTION
The Quarkus distribution of Keycloak doesn't have any default context path anymore:
https://www.keycloak.org/migration/migrating-to-quarkus#_default_context_path_changed

Reflect this change in the Keycloak client. If the used Keycloak installation happens to have some context path set (or e.g. a reverse proxy in front that assumes some HTTP path prefix), that can be included in the `KEYCLOAK_BASE_URL` setting.