### PR TITLE
Add ability to dry run profile deletion

### DIFF
--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -177,6 +177,7 @@ scalar DateTime
 
 input DeleteMyProfileMutationInput {
   authorizationCode: String!
+  dryRun: Boolean
   clientMutationId: String
 }
 

--- a/profiles/connected_services.py
+++ b/profiles/connected_services.py
@@ -126,17 +126,18 @@ def delete_connected_service_data(profile, authorization_code):
         _delete_service_connections_for_profile(profile, api_tokens, dry_run=True)
         _delete_service_connections_for_profile(profile, api_tokens, dry_run=False)
 
-    if _keycloak_admin_client and profile.user:
-        user_id = profile.user.uuid
 
-        try:
-            _keycloak_admin_client.delete_user(user_id)
-        except Exception as err:
-            if (
-                not isinstance(err, requests.HTTPError)
-                or err.response.status_code != 404
-            ):
-                raise ConnectedServiceDeletionFailedError("User deletion unsuccesful.")
+def delete_profile_from_keycloak(profile):
+    if not _keycloak_admin_client or not profile.user:
+        return
+
+    user_id = profile.user.uuid
+
+    try:
+        _keycloak_admin_client.delete_user(user_id)
+    except Exception as err:
+        if not isinstance(err, requests.HTTPError) or err.response.status_code != 404:
+            raise ConnectedServiceDeletionFailedError("User deletion unsuccessful.")
 
 
 def send_profile_changes_to_keycloak(instance):

--- a/profiles/connected_services.py
+++ b/profiles/connected_services.py
@@ -118,13 +118,14 @@ def _delete_service_connections_for_profile(profile, api_tokens, dry_run=False):
         )
 
 
-def delete_connected_service_data(profile, authorization_code):
+def delete_connected_service_data(profile, authorization_code, dry_run=False):
     if profile.effective_service_connections_qs().exists():
         tte = TunnistamoTokenExchange()
         api_tokens = tte.fetch_api_tokens(authorization_code)
 
         _delete_service_connections_for_profile(profile, api_tokens, dry_run=True)
-        _delete_service_connections_for_profile(profile, api_tokens, dry_run=False)
+        if not dry_run:
+            _delete_service_connections_for_profile(profile, api_tokens, dry_run=False)
 
 
 def delete_profile_from_keycloak(profile):

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1376,6 +1376,10 @@ class DeleteMyProfileMutation(relay.ClientIDMutation):
                 "service and operation specific GDPR API scopes."
             ),
         )
+        dry_run = graphene.Boolean(
+            required=False,
+            description="Can be used to see if the profile can be removed. Default is False.",
+        )
 
     @classmethod
     @login_and_service_required
@@ -1390,11 +1394,17 @@ class DeleteMyProfileMutation(relay.ClientIDMutation):
                 _("You do not have permission to perform this action.")
             )
 
-        delete_connected_service_data(profile, input["authorization_code"])
+        dry_run = input.get("dry_run", False)
 
-        delete_profile_from_keycloak(profile)
-        profile.delete()
-        info.context.user.delete()
+        delete_connected_service_data(
+            profile, input["authorization_code"], dry_run=dry_run
+        )
+
+        if not dry_run:
+            delete_profile_from_keycloak(profile)
+            profile.delete()
+            info.context.user.delete()
+
         return DeleteMyProfileMutation()
 
 

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1372,7 +1372,7 @@ class DeleteMyProfileMutation(relay.ClientIDMutation):
         authorization_code = graphene.String(
             required=True,
             description=(
-                "OAuth/OIDC authoziation code. When obtaining the code, it is required to use "
+                "OAuth/OIDC authorization code. When obtaining the code, it is required to use "
                 "service and operation specific GDPR API scopes."
             ),
         )
@@ -1446,7 +1446,7 @@ class Query(graphene.ObjectType):
         authorization_code=graphene.String(
             required=True,
             description=(
-                "OAuth/OIDC authoziation code. When obtaining the code, it is required to use "
+                "OAuth/OIDC authorization code. When obtaining the code, it is required to use "
                 "service and operation specific GDPR API scopes."
             ),
         ),
@@ -1588,7 +1588,7 @@ class Mutation(graphene.ObjectType):
             "Requires elevated privileges.\n\n"
             "Possible error codes:\n\n"
             "* `PERMISSION_DENIED_ERROR`: "
-            "The current user doesn't have the reguired permissions to perform this action.\n"
+            "The current user doesn't have the required permissions to perform this action.\n"
             "* `VALIDATION_ERROR`: "
             "The given input doesn't pass validation.",
             deprecation_reason="Renamed to createOrUpdateUserProfile",
@@ -1600,7 +1600,7 @@ class Mutation(graphene.ObjectType):
             "Requires elevated privileges.\n\n"
             "Possible error codes:\n\n"
             "* `PERMISSION_DENIED_ERROR`: "
-            "The current user doesn't have the reguired permissions to perform this action.\n"
+            "The current user doesn't have the required permissions to perform this action.\n"
             "* `VALIDATION_ERROR`: "
             "The given input doesn't pass validation."
         )

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -48,6 +48,7 @@ from utils.validation import model_field_validation
 
 from .connected_services import (
     delete_connected_service_data,
+    delete_profile_from_keycloak,
     download_connected_service_data,
 )
 from .enums import AddressType, EmailType, PhoneType
@@ -1391,6 +1392,7 @@ class DeleteMyProfileMutation(relay.ClientIDMutation):
 
         delete_connected_service_data(profile, input["authorization_code"])
 
+        delete_profile_from_keycloak(profile)
         profile.delete()
         info.context.user.delete()
         return DeleteMyProfileMutation()


### PR DESCRIPTION
Three features in the ticket:

- Add ability to dry run profile deletion
- Ability to delete data from only one service
- Return which services denied profile deletion and why to the caller

This is the first part.

Refs HP-1525