### PR TITLE
Deactivate getting connections for a service

### DIFF
--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -415,8 +415,8 @@ type ServiceNode implements Node {
   gdprUrl: String!
   gdprQueryScope: String!
   gdprDeleteScope: String!
-  serviceconnectionSet(before: String, after: String, first: Int, last: Int): ServiceConnectionTypeConnection!
   type: ServiceType @deprecated(reason: "See \'name\' field for a replacement.")
+  serviceconnectionSet(before: String, after: String, first: Int, last: Int): ServiceConnectionTypeConnection! @deprecated(reason: "Always returns an empty result. Getting connections for a service is not supported and there is no replacement.")
   title(language: TranslationLanguage): String
   description(language: TranslationLanguage): String
 }

--- a/services/tests/test_services_graphql_api.py
+++ b/services/tests/test_services_graphql_api.py
@@ -90,6 +90,49 @@ def test_normal_user_can_query_own_services(
     assert executed["data"] == expected_data
 
 
+def test_service_connections_of_service_always_returns_an_empty_result(
+    user_gql_client, service
+):
+    profile = ProfileFactory(user=user_gql_client.user)
+    ServiceConnectionFactory(profile=profile, service=service)
+
+    for p in ProfileFactory.create_batch(3):
+        ServiceConnectionFactory(profile=p, service=service)
+
+    query = """
+        {
+            myProfile {
+                serviceConnections {
+                    edges {
+                        node {
+                            service {
+                                serviceconnectionSet {
+                                    edges {
+                                        node {
+                                            id
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+    expected_data = {
+        "myProfile": {
+            "serviceConnections": {
+                "edges": [
+                    {"node": {"service": {"serviceconnectionSet": {"edges": []}}}}
+                ]
+            }
+        }
+    }
+    executed = user_gql_client.execute(query)
+    assert executed["data"] == expected_data
+
+
 @pytest.mark.parametrize("service__service_type", [ServiceType.BERTH])
 def test_normal_user_can_add_service(user_gql_client, service):
     ProfileFactory(user=user_gql_client.user)


### PR DESCRIPTION
Make `ServiceNode`'s `serviceconnectionSet` field return an empty result.