### PR TITLE
Add services query

### DIFF
--- a/docs/permissions.adoc
+++ b/docs/permissions.adoc
@@ -22,6 +22,11 @@ Since a GraphQL mutation for example can modify half a dozen different models, u
 *Note:* Use object permissions. Add the permission to the `Service` object for the users or groups that should have access.
 
 [%hardbreaks]
+*In admin UI:* services | service | Can view service
+*In code:* `services.view_service`
+*Purpose:* Needed to access the `services` query.
+
+[%hardbreaks]
 *In admin UI:* services | service connection | Can view service connection
 *In code:* `services.view_serviceconnection`
 *Purpose:* Needed to access the `serviceConnectionWithUserId` query.

--- a/open_city_profile/schema.py
+++ b/open_city_profile/schema.py
@@ -6,7 +6,7 @@ import services.schema
 
 
 class Query(
-    profiles.schema.Query, graphene.ObjectType,
+    profiles.schema.Query, services.schema.Query, graphene.ObjectType,
 ):
     pass
 

--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -346,7 +346,7 @@ type ProfileWithVerifiedPersonalInformationOutput implements Node {
 }
 
 type Query {
-  services(before: String, after: String, first: Int, last: Int): ServiceNodeConnection
+  services(before: String, after: String, first: Int, last: Int, clientId: String): ServiceNodeConnection
   profile(id: ID!, serviceType: ServiceType): ProfileNode
   myProfile: ProfileNode
   downloadMyProfile(authorizationCode: String!): JSONString

--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -418,6 +418,7 @@ type ServiceNode implements Node {
   gdprQueryScope: String!
   gdprDeleteScope: String!
   type: ServiceType @deprecated(reason: "See \'name\' field for a replacement.")
+  requiresServiceConnection: Boolean!
   serviceconnectionSet(before: String, after: String, first: Int, last: Int): ServiceConnectionTypeConnection! @deprecated(reason: "Always returns an empty result. Getting connections for a service is not supported and there is no replacement.")
   title(language: TranslationLanguage): String
   description(language: TranslationLanguage): String

--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -346,6 +346,7 @@ type ProfileWithVerifiedPersonalInformationOutput implements Node {
 }
 
 type Query {
+  services(before: String, after: String, first: Int, last: Int): ServiceNodeConnection
   profile(id: ID!, serviceType: ServiceType): ProfileNode
   myProfile: ProfileNode
   downloadMyProfile(authorizationCode: String!): JSONString

--- a/services/schema.py
+++ b/services/schema.py
@@ -1,6 +1,7 @@
 import graphene
 from django.db import transaction
 from django.db.utils import IntegrityError
+from django_filters import CharFilter, FilterSet
 from graphene import relay
 from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.types import DjangoObjectType
@@ -24,6 +25,18 @@ class AllowedDataFieldNode(DjangoParlerObjectType):
     class Meta:
         model = AllowedDataField
         interfaces = (relay.Node,)
+
+
+class ServiceFilter(FilterSet):
+    class Meta:
+        model = Service
+        fields = []
+
+    client_id = CharFilter(
+        field_name="client_ids__client_id",
+        label="Filters a service having this exact client id. "
+        "Because client ids are unique, the result can contain max one service.",
+    )
 
 
 class ServiceConnectionType(DjangoObjectType):
@@ -103,6 +116,7 @@ class AddServiceConnectionMutation(relay.ClientIDMutation):
 class Query(graphene.ObjectType):
     services = DjangoFilterConnectionField(
         ServiceNode,
+        filterset_class=ServiceFilter,
         description="Search for services. The results are paged using Relay.",
     )
 

--- a/services/schema.py
+++ b/services/schema.py
@@ -6,7 +6,7 @@ from graphene import relay
 from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.types import DjangoObjectType
 
-from open_city_profile.decorators import login_and_service_required
+from open_city_profile.decorators import login_and_service_required, permission_required
 from open_city_profile.exceptions import ServiceAlreadyExistsError
 from open_city_profile.graphene import DjangoParlerObjectType
 
@@ -124,8 +124,13 @@ class Query(graphene.ObjectType):
     services = DjangoFilterConnectionField(
         ServiceNode,
         filterset_class=ServiceFilter,
-        description="Search for services. The results are paged using Relay.",
+        description="Search for services. The results are paged using Relay.\n\n"
+        "Requires elevated privileges.",
     )
+
+    @permission_required("services.view_service")
+    def resolve_services(self, info, **kwargs):
+        return Service.objects
 
 
 class Mutation(graphene.ObjectType):

--- a/services/schema.py
+++ b/services/schema.py
@@ -51,6 +51,10 @@ class ServiceNode(DjangoParlerObjectType):
     type = AllowedServiceType(
         source="service_type", deprecation_reason="See 'name' field for a replacement.",
     )
+    requires_service_connection = graphene.Boolean(
+        required=True,
+        description="Does this service require a service connection to profile in order to receive the profile's data.",
+    )
     serviceconnection_set = DjangoFilterConnectionField(
         ServiceConnectionType,
         required=True,
@@ -73,6 +77,9 @@ class ServiceNode(DjangoParlerObjectType):
         )
         filter_fields = []
         interfaces = (relay.Node,)
+
+    def resolve_requires_service_connection(self, info, **kwargs):
+        return not self.is_profile_service
 
     def resolve_serviceconnection_set(self, info, **kwargs):
         return ServiceConnection.objects.none()

--- a/services/schema.py
+++ b/services/schema.py
@@ -100,6 +100,13 @@ class AddServiceConnectionMutation(relay.ClientIDMutation):
         return AddServiceConnectionMutation(service_connection=service_connection)
 
 
+class Query(graphene.ObjectType):
+    services = DjangoFilterConnectionField(
+        ServiceNode,
+        description="Search for services. The results are paged using Relay.",
+    )
+
+
 class Mutation(graphene.ObjectType):
     add_service_connection = AddServiceConnectionMutation.Field(
         description="Connect the currently authenticated user's profile to the given service.\n\nRequires "

--- a/services/tests/test_gql_services_query.py
+++ b/services/tests/test_gql_services_query.py
@@ -1,0 +1,26 @@
+from services.models import Service
+
+QUERY = """
+    query {
+        services {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_can_query_all_services(service_factory, anon_user_gql_client):
+    service_factory.create_batch(3)
+    # Get services via the model so that they are in the default order
+    services = Service.objects.all()
+
+    expected_service_edges = [{"node": {"name": s.name}} for s in services]
+
+    executed = anon_user_gql_client.execute(QUERY, service=None)
+
+    assert "errors" not in executed
+    assert executed["data"] == {"services": {"edges": expected_service_edges}}


### PR DESCRIPTION
A new GraphQL query for receiving general information about services. ~Doesn't require any authentication (should it?).~ Requires `services.view_service` permission.

Also adds a new flag to `ServiceNode`: `requiresServiceConnection`.