### PR TITLE
Remove obsolete ClientMutationID from the DeleteMyServiceDataMutation

### DIFF
--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -190,12 +190,10 @@ input DeleteMyServiceDataMutationInput {
   authorizationCode: String!
   serviceName: String!
   dryRun: Boolean
-  clientMutationId: String
 }
 
 type DeleteMyServiceDataMutationPayload {
   result: ServiceConnectionDeletionResult!
-  clientMutationId: String
 }
 
 input EmailInput {

--- a/profiles/tests/test_profiles_graphql_gdpr_api.py
+++ b/profiles/tests/test_profiles_graphql_gdpr_api.py
@@ -65,7 +65,6 @@ DELETE_MY_SERVICE_DATA_MUTATION = """
                 dryRun: $dryRun
             }
         ) {
-            clientMutationId
             result {
                 service {
                     name


### PR DESCRIPTION
The ClientMutationID functionality can be removed from the mutation as it has not yet been in use.

DeleteMyServiceDataMutation tests are removed from the test_profiles_graphql_gdpr_delete_without_results because the mutation can no longer be called without results.