### PR TITLE
Exclude service connection to Profile service in GraphQL

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -561,7 +561,7 @@ class ProfileNode(RestrictedProfileNode):
     )
 
     def resolve_service_connections(self, info, **kwargs):
-        return ServiceConnection.objects.filter(profile=self)
+        return self.effective_service_connections_qs()
 
     def resolve_sensitivedata(self, info, **kwargs):
         service = info.context.service

--- a/services/tests/test_gql_my_profile_service_connections_query.py
+++ b/services/tests/test_gql_my_profile_service_connections_query.py
@@ -86,6 +86,20 @@ def test_normal_user_can_query_own_services(
     assert executed["data"] == expected_data
 
 
+def test_profile_service_is_not_returned_in_service_connections(
+    profile_service, user_gql_client
+):
+    profile = ProfileFactory(user=user_gql_client.user)
+    ServiceConnectionFactory(profile=profile, service=profile_service)
+
+    expected_data = {"myProfile": {"serviceConnections": {"edges": []}}}
+
+    executed = user_gql_client.execute(
+        SERVICE_CONNECTIONS_QUERY, service=profile_service
+    )
+    assert executed["data"] == expected_data
+
+
 def test_service_connections_of_service_always_returns_an_empty_result(
     user_gql_client, service
 ):

--- a/services/tests/test_gql_my_profile_service_connections_query.py
+++ b/services/tests/test_gql_my_profile_service_connections_query.py
@@ -8,6 +8,33 @@ from open_city_profile.tests.graphql_test_helpers import do_graphql_call_as_user
 from services.enums import ServiceType
 from services.tests.factories import ProfileFactory, ServiceConnectionFactory
 
+SERVICE_CONNECTIONS_QUERY = """
+    {
+        myProfile {
+            serviceConnections {
+                edges {
+                    node {
+                        service {
+                            type
+                            name
+                            title
+                            description
+                            allowedDataFields {
+                                edges {
+                                    node {
+                                        fieldName
+                                        label
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
 
 @pytest.mark.parametrize("service__service_type", [ServiceType.BERTH])
 def test_normal_user_can_query_own_services(
@@ -21,32 +48,6 @@ def test_normal_user_can_query_own_services(
     service.allowed_data_fields.add(second_field)
     ServiceConnectionFactory(profile=profile, service=service)
 
-    query = """
-        {
-            myProfile {
-                serviceConnections {
-                    edges {
-                        node {
-                            service {
-                                type
-                                name
-                                title
-                                description
-                                allowedDataFields {
-                                    edges {
-                                        node {
-                                            fieldName
-                                            label
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    """
     expected_data = {
         "myProfile": {
             "serviceConnections": {
@@ -81,7 +82,7 @@ def test_normal_user_can_query_own_services(
             }
         }
     }
-    executed = user_gql_client.execute(query)
+    executed = user_gql_client.execute(SERVICE_CONNECTIONS_QUERY)
     assert executed["data"] == expected_data
 
 


### PR DESCRIPTION
The profile service doesn't need explicit service connections. Nonetheless, there are some such explicit service connections in the database. Don’t return such service connections from the GraphQL API.