### PR TITLE
HP-1685 Make GDPR delete dry-run request conform to the GDPR API spec

### DIFF
--- a/profiles/tests/test_profiles_graphql_gdpr_api.py
+++ b/profiles/tests/test_profiles_graphql_gdpr_api.py
@@ -443,8 +443,8 @@ def test_user_can_dry_run_profile_deletion(
 
     assert service1_mocker.call_count == 1
     assert service2_mocker.call_count == 1
-    assert "dry_run=True" in service1_mocker.request_history[0].text
-    assert "dry_run=True" in service2_mocker.request_history[0].text
+    assert service1_mocker.request_history[0].qs["dry_run"] == ["true"]
+    assert service2_mocker.request_history[0].qs["dry_run"] == ["true"]
     assert Profile.objects.filter(pk=profile.pk).exists()
     assert ServiceConnection.objects.count() == 2
 
@@ -500,7 +500,7 @@ def test_user_tries_deleting_his_profile_but_it_fails_partially(
     ServiceConnectionFactory(profile=profile, service=service_2)
 
     def get_response(request, context):
-        if not request.body or "dry_run" not in request.body:
+        if request.qs.get("dry_run") != ["true"]:
             context.status_code = 403
 
     requests_mock.delete(service_1.get_gdpr_url_for_profile(profile), status_code=204)
@@ -608,13 +608,13 @@ def test_user_can_delete_his_profile_using_correct_api_tokens(
 
     def get_response(request, context):
         if (
-            request.url == service_1_gdpr_url
+            service_1_gdpr_url in request.url
             and request.headers["authorization"] == f"Bearer {API_TOKEN_1}"
         ):
             return
 
         if (
-            request.url == service_2_gdpr_url
+            service_2_gdpr_url in request.url
             and request.headers["authorization"] == f"Bearer {API_TOKEN_2}"
         ):
             return
@@ -852,12 +852,12 @@ def test_user_can_delete_data_from_a_service(
     if dry_run:
         assert service_1_mocker.call_count == 1
         assert service_2_mocker.call_count == 0
-        assert "dry_run=True" in service_1_mocker.request_history[0].text
+        assert service_1_mocker.request_history[0].qs["dry_run"] == ["true"]
         assert ServiceConnection.objects.count() == 2
     else:
         assert service_1_mocker.call_count == 2
         assert service_2_mocker.call_count == 0
-        assert "dry_run=True" in service_1_mocker.request_history[0].text
+        assert service_1_mocker.request_history[0].qs["dry_run"] == ["true"]
         assert not service_1_mocker.request_history[1].text
         assert ServiceConnection.objects.count() == 1
         assert ServiceConnection.objects.first().service == service_2

--- a/profiles/tests/test_profiles_graphql_gdpr_delete_without_results.py
+++ b/profiles/tests/test_profiles_graphql_gdpr_delete_without_results.py
@@ -126,8 +126,8 @@ def test_user_can_dry_run_profile_deletion(
 
     assert service1_mocker.call_count == 1
     assert service2_mocker.call_count == 1
-    assert "dry_run=True" in service1_mocker.request_history[0].text
-    assert "dry_run=True" in service2_mocker.request_history[0].text
+    assert service1_mocker.request_history[0].qs["dry_run"] == ["true"]
+    assert service2_mocker.request_history[0].qs["dry_run"] == ["true"]
     assert Profile.objects.filter(pk=profile.pk).exists()
     assert ServiceConnection.objects.count() == 2
 
@@ -181,7 +181,7 @@ def test_user_tries_deleting_his_profile_but_it_fails_partially(
     ServiceConnectionFactory(profile=profile, service=service_2)
 
     def get_response(request, context):
-        if not request.body or "dry_run" not in request.body:
+        if request.qs.get("dry_run") != ["true"]:
             context.status_code = 403
 
     requests_mock.delete(service_1.get_gdpr_url_for_profile(profile), status_code=204)
@@ -247,13 +247,13 @@ def test_user_can_delete_his_profile_using_correct_api_tokens(
 
     def get_response(request, context):
         if (
-            request.url == service_1_gdpr_url
+            service_1_gdpr_url in request.url
             and request.headers["authorization"] == f"Bearer {API_TOKEN_1}"
         ):
             return
 
         if (
-            request.url == service_2_gdpr_url
+            service_2_gdpr_url in request.url
             and request.headers["authorization"] == f"Bearer {API_TOKEN_2}"
         ):
             return

--- a/services/models.py
+++ b/services/models.py
@@ -267,11 +267,11 @@ class ServiceConnection(SerializableMixin):
 
         data = {}
         if dry_run:
-            data["dry_run"] = True
+            data["dry_run"] = "true"
 
         try:
             response = requests.delete(
-                url, auth=BearerAuth(api_token), timeout=5, data=data
+                url, auth=BearerAuth(api_token), timeout=5, params=data
             )
         except requests.RequestException:
             return _add_error_to_result(


### PR DESCRIPTION
Moved the dry_run into a query parameter and changed the value to lower case "true". Previously the dry_run parameter was set in the body and the value was "True".

Here is the dry-run part of the current API specification:
```
    - name: dry_run
      in: query
      description: If set to true, the actual removal will not be made...
      required: false
      schema:
        type: boolean
```

Refs HP-1685