### PR TITLE
OpenAPI specification for GDPR API implementations

### DIFF
--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -7,7 +7,7 @@ paths:
   /profiles/{id}:
     get:
       summary: Retrieve all of the data related to the given id.
-      description: Retrieve all of the data related to the given id, represented in a tree structure. Depending on the `displayable` parameter, the response may contain additional metadata which can be used when formatting the data for a user.
+      description: Retrieve all of the data related to the given id, represented in a tree structure.
       tags:
       - profiles
       operationId: getProfile
@@ -18,12 +18,6 @@ paths:
         required: true
         schema:
           type: string
-      - name: displayable
-        in: query
-        description: If this is set to true, the response is going to be used to display formatted content to a user. This means that the service may add additional data to the response so that the calling system may use that data to format the response further. See the specification of '#components/schemas/Node'. If this is false or missing, then the response is going to be used in some form of machine readable output.
-        required: false
-        schema:
-          type: boolean
       responses:
         200:
           description: Returned when the retrieval is successful. The body contains the profile data in a tree structure.
@@ -89,15 +83,7 @@ components:
       type: object
       additionalProperties:
         type: string
-        example: 'Some message/label in the language specified by the key'
-    Formatting:
-      type: object
-      properties:
-        type:
-          type: string
-          enum: ['string', 'date', 'decimal']
-        precision:
-          type: integer
+        example: 'Some message in the language specified by the key'
     Error:
       type: object
       required:
@@ -119,116 +105,48 @@ components:
       example:
         {
           "key": "CUSTOMER",
-          "label": {
-            "fi": "Asiakkaan tiedot",
-            "en": "Customer information"
-          },
           "children": [
             {
               "key": "NAME",
-              "label": {
-                "fi": "Nimi",
-                "en": "Name"
-              },
               "value": "John Doe"
             },
             {
               "key": "ADDRESS",
-              "label": {
-                "fi": "Osoite",
-                "en": "Address"
-              },
               "value": "Bourbon Street 123"
             },
             {
               "key": "RESERVED_PARKING_SPACES",
-              "label": {
-                "fi": "Varatut parkkipaikat",
-                "en": "Reserved parking spaces"
-              },
               "children": [
                 {
                   "key": "PARKING_SPACE",
-                  "label": {
-                    "fi": "Parkkipaikka",
-                    "en": "Parking space"
-                  },
                   "children": [
                     {
                       "key": "NUMBER",
-                      "label": {
-                        "fi": "Parkkipaikan numero",
-                        "en": "Parking space number",
-                      },
-                      "formatting": {
-                        "datatype": "integer"
-                      },
                       "value": "66"
                     },
                     {
                       "key": "LENGTH",
-                      "label": {
-                        "fi": "Parkkipaikan pituus",
-                        "en": "Parking space length",
-                      },
-                      "formatting": {
-                        "datatype": "decimal",
-                        "precision": "2"
-                      },
                       "value": "4.280000000000"
                     },
                     {
                       "key": "RESERVATION_DATE",
-                      "label": {
-                        "fi": "Varauspäivämäärä",
-                        "en": "Reservation date",
-                      },
-                      "formatting": {
-                        "datatype": "date"
-                      },
                       "value": "2020-01-01"
                     }
                   ]
                 },
                 {
                   "key": "PARKING_SPACE",
-                  "label": {
-                    "fi": "Parkkipaikka",
-                    "en": "Parking space"
-                  },
                   "children": [
                     {
                       "key": "NUMBER",
-                      "label": {
-                        "fi": "Parkkipaikan numero",
-                        "en": "Parking spaces number",
-                      },
-                      "formatting": {
-                        "datatype": "integer"
-                      },
                       "value": "68"
                     },
                     {
                       "key": "LENGTH",
-                      "label": {
-                        "fi": "Parkkipaikan pituus",
-                        "en": "Parking space length",
-                      },
-                      "formatting": {
-                        "datatype": "decimal",
-                        "precision": "2"
-                      },
                       "value": "3.90000000004"
                     },
                     {
                       "key": "RESERVATION_DATE",
-                      "label": {
-                        "fi": "Varauspäivämäärä",
-                        "en": "Reservation date",
-                      },
-                      "formatting": {
-                        "datatype": "date"
-                      },
                       "value": "2020-02-02"
                     }
                   ]
@@ -237,16 +155,12 @@ components:
             }
           ]
         }
-      description: This represents a single node in the tree structure. You may use this as a key-value pair or only as a container for the child elements or a combination of both. The `label` and `formatting` properties should only be used when `displayable=true`. `label` should contain a label for this Node, preferrably in all fi/sv/en languages to facilitate localization. `formatting` may contain hints for formatting the node's value for the UI.
+      description: This represents a single node in the tree structure. You may use this as a key-value pair or only as a container for the child elements or a combination of both.
       type: object
       properties:
         key:
           description: This should be a technical identifier for the Node so that it can be used by a parser. If it's feasible, use a database column name here.
           type: string
-        label:
-          $ref: '#/components/schemas/LocalizedMessage'
-        formatting:
-          $ref: '#/components/schemas/Formatting'
         value:
           description: This is the value of the Node. This can be left empty if you want to use this Node as a sort of heading.
           type: string

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Open-city-profile GDPR API
   description: 'This is the API for performing GDPR operations on user data which relates to a certain profile. The GDPR operations provide the functionalities for removing all data or downloading all stored data.'
-  version: 1.0.0
+  version: 1.1.0
 paths:
   /service_specific_path/{profile_or_user_id}:
     description: The service can basically choose their URL by themself. The URL will have a user UUID or a profile ID (also an UUID, but separate from the user UUID) somewhere in the path.

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -1,0 +1,265 @@
+openapi: 3.0.3
+info:
+  title: Helsinkiprofile GDPR API
+  description: 'This is the API for performing GDPR operations on user data which relates to a certain Helsinkiprofile. The GDPR operations provide the functionalities for removing all data or downloading all stored data.'
+  termsOfService: ''
+  contact:
+    email: kuva-open-city-profile-developers@googlegroups.com
+  version: 1.0.0
+externalDocs:
+  description: Read more about Helsinkiprofile in Confluence
+  url: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/DD/pages/917571
+servers:
+- url: https://localhost:8888/gdpr-api/v1
+paths:
+  /profiles/{id}:
+    get:
+      summary: Retrieve all of the data related to the given id.
+      description: Retrieve all of the data related to the given id, represented in a tree structure. Depending on the `displayable` parameter, the response may contain additional metadata which can be used when formatting the data for a user.
+      tags:
+      - profiles
+      operationId: getProfile
+      parameters:
+      - name: id
+        in: path
+        description: Profile id whose data is retrieved
+        required: true
+        schema:
+          type: string
+      - name: displayable
+        in: query
+        description: If this is set to true, the response is going to be used to display formatted content to a user. This means that the service may add additional data to the response so that the calling system may use that data to format the response further. See the specification of '#components/schemas/Node'. If this is false or missing, then the response is going to be used in some form of machine readable output.
+        required: false
+        schema:
+          type: boolean
+      responses:
+        200:
+          description: Returned when the retrieval is successful. The body contains the profile data in a tree structure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+        400:
+          description: Request’s parameters fail validation
+        401:
+          description: Request’s credentials are missing or invalid.
+        404:
+          description: Profile’s data cannot be found with the given id.
+        500:
+          description: There has been an unexpected error during the call.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      summary: Delete all data related to the given id.
+      description: Deletes all data related to the given profile id, or just checks if the data can be deleted, depending on the `dry_run` parameter.
+      tags:
+      - profiles
+      operationId: deleteProfile
+      parameters:
+      - name: id
+        in: path
+        description: Profile id to delete.
+        required: true
+        schema:
+          type: string
+      - name: dry_run
+        in: query
+        description: If set to true, the actual removal will not be made. Instead the business rules are checked to see if the removal can be made.
+        required: false
+        schema:
+          type: boolean
+      responses:
+        204:
+          description: Returned after a successful operation. Depending on the `dry_run` variable, this means either that the profile data has been deleted or that the called service is currently allowing the deletion.
+        400:
+          description: Request’s parameters fail validation
+        401:
+          description: Request’s credentials are missing or invalid.
+        403:
+          description: Profile cannot be removed from the called service because of some business rules. The reason(s) for failure are detailed in the returned response object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: Profile’s data cannot be found with the given id.
+        500:
+          description: There has been an unexpected error during the call.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    LocalizedMessage:
+      type: object
+      additionalProperties:
+        type: string
+        example: 'Some message/label in the language specified by the key'
+    Formatting:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: ['string', 'date', 'decimal']
+        precision:
+          type: integer
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          $ref: '#/components/schemas/LocalizedMessage'
+    ErrorResponse:
+      type: "object"
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error'
+    Node:
+      example:
+        {
+          "key": "CUSTOMER",
+          "label": {
+            "fi": "Asiakkaan tiedot",
+            "en": "Customer information"
+          },
+          "children": [
+            {
+              "key": "NAME",
+              "label": {
+                "fi": "Nimi",
+                "en": "Name"
+              },
+              "value": "John Doe"
+            },
+            {
+              "key": "ADDRESS",
+              "label": {
+                "fi": "Osoite",
+                "en": "Address"
+              },
+              "value": "Bourbon Street 123"
+            },
+            {
+              "key": "RESERVED_PARKING_SPACES",
+              "label": {
+                "fi": "Varatut parkkipaikat",
+                "en": "Reserved parking spaces"
+              },
+              "children": [
+                {
+                  "key": "PARKING_SPACE",
+                  "label": {
+                    "fi": "Parkkipaikka",
+                    "en": "Parking space"
+                  },
+                  "children": [
+                    {
+                      "key": "NUMBER",
+                      "label": {
+                        "fi": "Parkkipaikan numero",
+                        "en": "Parking space number",
+                      },
+                      "formatting": {
+                        "datatype": "integer"
+                      },
+                      "value": "66"
+                    },
+                    {
+                      "key": "LENGTH",
+                      "label": {
+                        "fi": "Parkkipaikan pituus",
+                        "en": "Parking space length",
+                      },
+                      "formatting": {
+                        "datatype": "decimal",
+                        "precision": "2"
+                      },
+                      "value": "4.280000000000"
+                    },
+                    {
+                      "key": "RESERVATION_DATE",
+                      "label": {
+                        "fi": "Varauspäivämäärä",
+                        "en": "Reservation date",
+                      },
+                      "formatting": {
+                        "datatype": "date"
+                      },
+                      "value": "2020-01-01"
+                    }
+                  ]
+                },
+                {
+                  "key": "PARKING_SPACE",
+                  "label": {
+                    "fi": "Parkkipaikka",
+                    "en": "Parking space"
+                  },
+                  "children": [
+                    {
+                      "key": "NUMBER",
+                      "label": {
+                        "fi": "Parkkipaikan numero",
+                        "en": "Parking spaces number",
+                      },
+                      "formatting": {
+                        "datatype": "integer"
+                      },
+                      "value": "68"
+                    },
+                    {
+                      "key": "LENGTH",
+                      "label": {
+                        "fi": "Parkkipaikan pituus",
+                        "en": "Parking space length",
+                      },
+                      "formatting": {
+                        "datatype": "decimal",
+                        "precision": "2"
+                      },
+                      "value": "3.90000000004"
+                    },
+                    {
+                      "key": "RESERVATION_DATE",
+                      "label": {
+                        "fi": "Varauspäivämäärä",
+                        "en": "Reservation date",
+                      },
+                      "formatting": {
+                        "datatype": "date"
+                      },
+                      "value": "2020-02-02"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      description: This represents a single node in the tree structure. You may use this as a key-value pair or only as a container for the child elements or a combination of both. The `label` and `formatting` properties should only be used when `displayable=true`. `label` should contain a label for this Node, preferrably in all fi/sv/en languages to facilitate localization. `formatting` may contain hints for formatting the node's value for the UI.
+      type: object
+      properties:
+        key:
+          description: This should be a technical identifier for the Node so that it can be used by a parser. If it's feasible, use a database column name here.
+          type: string
+        label:
+          $ref: '#/components/schemas/LocalizedMessage'
+        formatting:
+          $ref: '#/components/schemas/Formatting'
+        value:
+          description: This is the value of the Node. This can be left empty if you want to use this Node as a sort of heading.
+          type: string
+        children:
+          description: These are the current Node's children which can be for example the properties of an entity or more complex Nodes themselves.
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -15,14 +15,14 @@ paths:
         type: string
         format: uuid
     get:
-      summary: Retrieve all of the data related to the given id.
-      description: Retrieve all of the data related to the given id, represented in a tree structure.
+      summary: Retrieve all personal data related to the identified profile.
+      description: Retrieve all personal data related to the identified profile, represented in a tree structure.
       tags:
       - profiles
       operationId: getProfile
       responses:
         200:
-          description: Returned when the retrieval is successful. The body contains the profile data in a tree structure.
+          description: Returns the data for the profile. The body contains the profile data in a tree structure.
           content:
             application/json:
               schema:
@@ -40,7 +40,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
     delete:
-      summary: Delete all data related to the given id.
+      summary: Perform the needed actions so that the service no longer contains personal data related to the profile.
       description: Deletes all data related to the given profile id, or just checks if the data can be deleted, depending on the `dry_run` parameter.
       tags:
       - profiles

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -1,7 +1,81 @@
 openapi: 3.0.3
 info:
   title: Open-city-profile GDPR API
-  description: 'This is the API for performing GDPR operations on user data which relates to a certain profile. The GDPR operations provide the functionalities for removing all data or downloading all stored data.'
+  description: |-
+    This is the API for performing GDPR operations on user data which relates to a certain profile. The GDPR operations
+    provide the functionalities for removing all data or downloading all stored data.
+
+    The GDPR API consists of a single URL that is called using HTTP. The different use cases are separated by the used
+    HTTP method and parameters within the call.
+
+    The service can basically choose their URL by themself. The URL will have a user UUID or a profile ID (also an UUID,
+    but separate from the user UUID) somewhere in the path. The GDPR API URL could for example be any of these
+    (`$user_uuid` and `$profile_id` would be replaced with the corresponding UUID):
+
+        https://myservice.hel.fi/api/v1/gdpr/$profile_id
+        https://myservice.hel.fi/user/$user_uuid/gdpr-api
+
+    The UUID representing any id will be inserted into the path with this format: `f611424a-9668-435e-8473-1501c4d67af5`.
+
+    ## Authorization of the GDPR API
+
+    The service's GDPR API implementation must perform appropriate authorization checks before allowing access to the
+    endpoints. If authorization fails, a `401` HTTP status code must be returned.
+
+    As a prerequisite, the GDPR API implementation must be aware of a trusted OpenID Provider (OP), identified by its
+    URL (see [OpenID Connect Core 1.0 specification](https://openid.net/specs/openid-connect-core-1_0.html)). Some
+    configuration is also needed in that OP, which is done by the Helsinki profile team. As an output of that
+    configuration some identifiers are created that will be used in the authorization process that a GDPR API
+    implementation must perform.
+
+    The caller of the GDPR API provides a token in the HTTP request which is to be used for authorization. The token is
+    provided in an HTTP `Authorization` header as specified in
+    [RFC 6750 section 2.1](https://www.rfc-editor.org/rfc/rfc6750#section-2.1). The token is a JWT as specified in
+    [RFC 7519](https://www.rfc-editor.org/rfc/rfc7519). The token is signed but not encrypted.
+
+    The GDPR API implementation must perform the following authorization checks:
+
+    1. Verify the signature of the JWT as specified in [RFC 7515](https://www.rfc-editor.org/rfc/rfc7515). The needed
+    public key can be obtained from the OP's JSON Web Key Set document, which can be fetched from the URL specified by
+    the `jwks_uri` in the OP configuration metadata. The way to obtain the OP configuration metadata is specified in the
+    [OpenID Connect Discovery 1.0 specification](https://openid.net/specs/openid-connect-discovery-1_0.html).
+
+    1. Validate the `iss` claim. The value must match exactly to the URL of the trusted OP. See
+    [RFC 7519 section 4.1.1](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.1).
+
+    1. Validate the `aud` claim. The `aud` claim identifies the party to whom the token is meant for, in this case the
+    specific GDPR API implementation. The value must match exactly to the value agreed with Helsinki profile team. See
+    [RFC 7519 section 4.1.3](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3).
+
+    1. Validate the `exp` claim as specified in
+    [RFC 7519 section 4.1.4](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4).
+
+    1. Validate the `sub` claim if applicable. The `sub` claim contains the UUID of the user who is performing the GDPR
+    API request. Check that this UUID corresponds to the same profile/user that is identified in the GDPR API’s URL. If
+    the GDPR API implementation doesn’t handle user UUIDs at all, this step can not be performed and may be skipped. See
+    [RFC 7519 section 4.1.2](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.2).
+
+    1. Validate API scopes. Helsinki profile team has provided two API scope values for the service, one for each GDPR
+    API use case. The API scope values may look for example like this:<br/><br/>
+    `https://api.hel.fi/auth/myservice.gdprquery` (for the data download use case)<br/>
+    `https://api.hel.fi/auth/myservice.gdprdelete` (for the data deletion use case)<br/><br/>
+    Each of these values actually consists of two parts, a domain part, and a scope part, separated by the last slash
+    (`/`) character. In the example values above in both the domain part is `https://api.hel.fi/auth`. The scope values
+    are `myservice.gdprquery` and `myservice.gdprdelete`. The domain value is the same for both API scopes of a service.
+    The scope values follow the structure shown here, which is a service specific identifier (`myservice`), followed by
+    a dot (`.`), followed by either `gdprquery` or `gdprdelete`.<br/><br/>
+    Depending on which use case of GDPR API is used, select the correct API scope value. Split it into the domain and
+    scope parts. Look for a claim from the JWT named similarly to the domain. The claim's value is an array of strings.
+    Verify that the scope is found from that array.<br/><br/>
+    Continuing with the previously shown example API scope values, a valid claim for the data download use case could
+    look for example like this:<br/><br/>
+    `"https://api.hel.fi/auth": [ "myservice.gdprquery", "other_scope" ]`
+
+    If all the above checks succeed, the authorization passes.
+
+    The last step in the above list (API scope validation) is a Helsinki specific extension. All the other steps are
+    specified by OpenID Connect and other specifications. That means that there exists libraries that can help in
+    implementation of the authorization logic.
   version: 1.1.0
 paths:
   /service_specific_path/{profile_or_user_id}:
@@ -22,13 +96,47 @@ paths:
       operationId: getProfile
       responses:
         200:
-          description: Returns the data for the profile. The body contains the profile data in a tree structure.
+          description: |-
+            Returns the data for the profile. The body contains the profile data in a tree structure.
+
+            ## The effect of authentication level
+
+            Users can authenticate with different levels of assurance. The level of assurance is included in the JWT
+            used for authorization in the `loa` claim. The possible values for the `loa` claim are `low`, `substantial`,
+            `high` and `unknown`. If the service requires a certain level of assurance for the user to control some of
+            their personal data, this same requirement needs to be considered also in the GDPR API implementation. For
+            example, if at least `substantial` level of assurance is required to create a contract with the service,
+            perhaps the same level of assurance is required also to retrieve personal data related to this contract via
+            the GDPR API. Any such requirement needs to be decided by the service itself.
+
+            **Note**: even if the service itself uses and accepts only high enough authentication levels in its own UI,
+            the GDPR API can still be called with any authentication level. That’s because the user requesting their
+            data is not authenticated to the service but to the Helsinki Profile UI, which accepts any level of
+            authentication.
+
+            If the level of assurance isn’t high enough for getting some data when using the GDPR API, an error message
+            can be included into the returned data. The response could then look for example like this:
+
+                {
+                  "key": "CUSTOMER",
+                  "children": [
+                    {
+                      "key": "NOT_SO_SECRET_DATA",
+                      "value": "This data is available with any level of assurance"
+                    },
+                    {
+                      "key": "SECRET_DATA",
+                      "error": "Insufficient authentication level to read data"
+                    }
+                  ]
+                }
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Node'
         204:
-          description: There is no data related to the profile. This can happen because the service does not contain such data for the profile or is completely unaware of the identified profile.
+          description: "There is no personal data related to the profile. This can happen because the service does not
+            contain such data for the profile or is completely unaware of the identified profile."
         400:
           description: Request’s parameters fail validation
         401:
@@ -48,7 +156,10 @@ paths:
       parameters:
       - name: dry_run
         in: query
-        description: If set to true, the actual removal will not be made. Instead the business rules are checked to see if the removal can be made.
+        description: "If set to `true`, the API must do all checks it would normally do before performing the deletion,
+          without actually deleting any data. It should then return an HTTP response that it would normally return when
+          performing the deletion, either allowing or denying the deletion. A request with this parameter can be used to
+          check whether the deletion would be allowed."
         required: false
         schema:
           type: boolean
@@ -63,7 +174,8 @@ paths:
         401:
           description: Request’s credentials are missing or invalid.
         403:
-          description: Profile cannot be removed from the called service because of some business rules. The reason(s) for failure are detailed in the returned response object.
+          description: "Service data related to the identified profile can't be removed from the called service because
+            of some legal reason. The reason(s) for failure are detailed in the response."
           content:
             application/json:
               schema:
@@ -79,7 +191,9 @@ components:
     LocalizedMessage:
       type: object
       additionalProperties:
-        description: A human-readable message in the language specified by the key.
+        description: "Human readable error messages localized to various languages: the object’s keys specify languages
+          and the values are the localized messages. The language codes are not well specified. It’s suggested that
+          services provide any messages in Finnish (`fi`), Swedish (`sv`) and English (`en`)."
         type: string
       example:
         en: "Existing contract"
@@ -92,7 +206,8 @@ components:
         - message
       properties:
         code:
-          description: A service specific error code for debugging purposes.
+          description: "A service specific error code for debugging purposes.
+            There is no specification for allowed values."
           type: string
           example: CONTRACT
         message:
@@ -162,13 +277,17 @@ components:
       type: object
       properties:
         key:
-          description: This should be a technical identifier for the Node so that it can be used by a parser. If it's feasible, use a database column name here.
+          description: "This should be a technical identifier for the Node so that it can be used by a parser. As a
+            convention the value of this member should be formatted as `SNAKE_CASE_WITH_CAPITAL_LETTERS`."
           type: string
         value:
-          description: This is the value of the Node. This can be left empty if you want to use this Node as a sort of heading.
+          description: "This is the value of the Node. Usually a Node contains either this or the `children` property,
+            but not both. Note that string is the only accepted data type! Otherwise this property’s value has no
+            specified format(s)."
           type: string
         children:
-          description: These are the current Node's children which can be for example the properties of an entity or more complex Nodes themselves.
+          description: "These are the current Node's children which can be for example the properties of an entity or
+            more complex Nodes themselves. Usually a Node contains either this or the `value` property, but not both."
           type: array
           items:
             $ref: '#/components/schemas/Node'

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -25,12 +25,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Node'
+        204:
+          description: There is no data related to the profile. This can happen because the service does not contain such data for the profile or is completely unaware of the identified profile.
         400:
           description: Request’s parameters fail validation
         401:
           description: Request’s credentials are missing or invalid.
-        404:
-          description: Profile’s data cannot be found with the given id.
         500:
           description: There has been an unexpected error during the call.
           content:
@@ -58,7 +58,10 @@ paths:
           type: boolean
       responses:
         204:
-          description: Returned after a successful operation. Depending on the `dry_run` variable, this means either that the profile data has been deleted or that the called service is currently allowing the deletion.
+          description: |-
+            The service allows and has done everything needed so that it no longer contains personal data for the identified profile. This response is also given in the case that the service does not contain any data for the profile or is completely unaware of the identified profile.
+
+            If the `dry_run` parameter is `true`, and no actual data erasure takes place, this response means that the service allows the data erasure.
         400:
           description: Request’s parameters fail validation
         401:
@@ -69,8 +72,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        404:
-          description: Profile’s data cannot be found with the given id.
         500:
           description: There has been an unexpected error during the call.
           content:

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -34,7 +34,7 @@ paths:
         401:
           description: Request’s credentials are missing or invalid.
         500:
-          description: There has been an unexpected error during the call.
+          description: There has been an unexpected error during the call. Errors may be returned with the specified response body but it's not mandatory. Responses that are not according to the specified schema are skipped.
           content:
             application/json:
               schema:
@@ -69,7 +69,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         500:
-          description: There has been an unexpected error during the call.
+          description: There has been an unexpected error during the call. Errors may be returned with the specified response body but it's not mandatory. Responses that are not according to the specified schema are skipped.
           content:
             application/json:
               schema:

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -2,15 +2,7 @@ openapi: 3.0.3
 info:
   title: Open-city-profile GDPR API
   description: 'This is the API for performing GDPR operations on user data which relates to a certain profile. The GDPR operations provide the functionalities for removing all data or downloading all stored data.'
-  termsOfService: ''
-  contact:
-    email: kuva-open-city-profile-developers@googlegroups.com
   version: 1.0.0
-externalDocs:
-  description: Read more about Helsinkiprofile in Confluence
-  url: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/DD/pages/917571
-servers:
-- url: https://localhost:8888/gdpr-api/v1
 paths:
   /profiles/{id}:
     get:

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -81,6 +81,10 @@ components:
       additionalProperties:
         description: A human-readable message in the language specified by the key.
         type: string
+      example:
+        en: "Existing contract"
+        fi: "Voimassaoleva sopimus"
+        sv: "Gällande avtal"
     Error:
       type: object
       required:
@@ -90,6 +94,7 @@ components:
         code:
           description: A service specific error code for debugging purposes.
           type: string
+          example: CONTRACT
         message:
           $ref: '#/components/schemas/LocalizedMessage'
     ErrorResponse:

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -4,20 +4,21 @@ info:
   description: 'This is the API for performing GDPR operations on user data which relates to a certain profile. The GDPR operations provide the functionalities for removing all data or downloading all stored data.'
   version: 1.0.0
 paths:
-  /profiles/{id}:
+  /profiles/{profile_or_user_id}:
+    parameters:
+    - name: profile_or_user_id
+      in: path
+      description: Profile or user id to identify the profile. The implementation may choose which id and at which location in the path (it doesn't need to be the last part in the path) they want to use.
+      required: true
+      schema:
+        type: string
+        format: uuid
     get:
       summary: Retrieve all of the data related to the given id.
       description: Retrieve all of the data related to the given id, represented in a tree structure.
       tags:
       - profiles
       operationId: getProfile
-      parameters:
-      - name: id
-        in: path
-        description: Profile id whose data is retrieved
-        required: true
-        schema:
-          type: string
       responses:
         200:
           description: Returned when the retrieval is successful. The body contains the profile data in a tree structure.
@@ -44,12 +45,6 @@ paths:
       - profiles
       operationId: deleteProfile
       parameters:
-      - name: id
-        in: path
-        description: Profile id to delete.
-        required: true
-        schema:
-          type: string
       - name: dry_run
         in: query
         description: If set to true, the actual removal will not be made. Instead the business rules are checked to see if the removal can be made.

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -79,8 +79,8 @@ components:
     LocalizedMessage:
       type: object
       additionalProperties:
+        description: A human-readable message in the language specified by the key.
         type: string
-        example: 'Some message in the language specified by the key'
     Error:
       type: object
       required:
@@ -88,6 +88,7 @@ components:
         - message
       properties:
         code:
+          description: A service specific error code for debugging purposes.
           type: string
         message:
           $ref: '#/components/schemas/LocalizedMessage'

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -4,7 +4,8 @@ info:
   description: 'This is the API for performing GDPR operations on user data which relates to a certain profile. The GDPR operations provide the functionalities for removing all data or downloading all stored data.'
   version: 1.0.0
 paths:
-  /profiles/{profile_or_user_id}:
+  /service_specific_path/{profile_or_user_id}:
+    description: The service can basically choose their URL by themself. The URL will have a user UUID or a profile ID (also an UUID, but separate from the user UUID) somewhere in the path.
     parameters:
     - name: profile_or_user_id
       in: path

--- a/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
+++ b/open_city_profile/static/open-city-profile/gdpr-api-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
-  title: Helsinkiprofile GDPR API
-  description: 'This is the API for performing GDPR operations on user data which relates to a certain Helsinkiprofile. The GDPR operations provide the functionalities for removing all data or downloading all stored data.'
+  title: Open-city-profile GDPR API
+  description: 'This is the API for performing GDPR operations on user data which relates to a certain profile. The GDPR operations provide the functionalities for removing all data or downloading all stored data.'
   termsOfService: ''
   contact:
     email: kuva-open-city-profile-developers@googlegroups.com

--- a/open_city_profile/urls.py
+++ b/open_city_profile/urls.py
@@ -3,7 +3,9 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import include, path
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import TemplateView
 
 from open_city_profile.views import GraphQLView
 
@@ -16,6 +18,17 @@ urlpatterns = [
         ),
     ),
     path("auth/", include("helusers.urls")),
+    path(
+        "docs/gdpr-api/",
+        TemplateView.as_view(
+            template_name="swagger-ui.html",
+            extra_context={
+                "title": _("Open-city-profile GDPR API specification"),
+                "openapi_url": "open-city-profile/gdpr-api-openapi.yaml",
+            },
+        ),
+        name="gdpr-api-docs",
+    ),
 ]
 
 

--- a/templates/swagger-ui.html
+++ b/templates/swagger-ui.html
@@ -1,0 +1,24 @@
+{% load i18n static %}
+{% get_current_language as LANGUAGE_CODE %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE|default:"en" }}">
+  <head>
+    <title>{{ title }}</title>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@4.15.5/swagger-ui.css" integrity="sha512-3ZF6q2IwJ/o3zbm5kBJX1RtjPFxnFcTBH+pa/jtnvvhygsYFcEqX+T9guR01rI8gozi4fPU95W+SZES6ew28qA==" crossorigin="anonymous">
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-bundle.js" integrity="sha512-bqxUYoYPf4DzvJH9o51SnEYzjylQLBD4Zua6CFq/uB71a7yxjEC7YPxHPreZqJEmbrR2litKgWGf6BIkhTna2A==" crossorigin="anonymous"></script>
+    <script>
+      window.onload = () => {
+        window.ui = SwaggerUIBundle({
+          url: "{% static openapi_url %}",
+          dom_id: '#swagger-ui',
+          supportedSubmitMethods: [],
+        });
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Brought the specification from internal documentation system and updated it.

Now also includes a live documentation page. Start the open-city-profile server and load `/docs/gdpr-api/` path.