### PR TITLE
When profile data sending to Keycloak fails, keep own database untouched

### DIFF
--- a/open_city_profile/tests/asserts.py
+++ b/open_city_profile/tests/asserts.py
@@ -32,5 +32,5 @@ def assert_match_error_code(response, error_code):
     error = response["errors"][0]
     assert "extensions" in error
     extensions = error["extensions"]
-    assert "code" in extensions
-    assert extensions["code"] == error_code
+    assert "code" in extensions, error
+    assert extensions["code"] == error_code, error

--- a/profiles/apps.py
+++ b/profiles/apps.py
@@ -6,4 +6,3 @@ class ProfilesConfig(AppConfig):
 
     def ready(self):
         import profiles.log_signals  # noqa isort:skip
-        import profiles.signals  # noqa isort:skip

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -107,10 +107,23 @@ def _create_nested(model, profile, data):
         item.save()
 
 
-def _update_nested(model, profile, data, field_callback):
+def _update_nested(node, profile, data, field_callback):
+    model = node._meta.model
+
     for update_input in filter(None, data):
         id = update_input.pop("id")
-        item = model.objects.get(profile=profile, pk=from_global_id(id)[1])
+        try:
+            id_type, id_id = from_global_id(id)
+            if id_type != node._meta.name:
+                raise Exception()
+            id_id = int(id_id)
+        except Exception:
+            raise model.DoesNotExist(
+                f"{model._meta.object_name} with id {id} not found"
+            )
+
+        item = model.objects.get(profile=profile, pk=id_id)
+
         for field, value in update_input.items():
             if field_callback:
                 field_callback(item, field, value)
@@ -138,12 +151,12 @@ def update_profile(profile, profile_data):
     ]
     nested_to_update = [
         (
-            Email,
+            EmailNode,
             profile_data.pop("update_emails", []),
             email_change_makes_it_unverified,
         ),
-        (Phone, profile_data.pop("update_phones", []), None),
-        (Address, profile_data.pop("update_addresses", []), None),
+        (PhoneNode, profile_data.pop("update_phones", []), None),
+        (AddressNode, profile_data.pop("update_addresses", []), None),
     ]
     nested_to_delete = [
         (Email, profile_data.pop("remove_emails", [])),
@@ -163,8 +176,8 @@ def update_profile(profile, profile_data):
     for model, data in nested_to_create:
         _create_nested(model, profile, data)
 
-    for model, data, field_callback in nested_to_update:
-        _update_nested(model, profile, data, field_callback)
+    for node, data, field_callback in nested_to_update:
+        _update_nested(node, profile, data, field_callback)
 
     for model, data in nested_to_delete:
         _delete_nested(model, profile, data)

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1284,7 +1284,12 @@ class UpdateMyProfileMutation(relay.ClientIDMutation):
             if sensitive_data:
                 update_sensitivedata(profile, sensitive_data)
 
-        send_profile_changes_to_keycloak(profile)
+        send_profile_changes_to_keycloak(
+            profile.user.uuid,
+            profile.first_name,
+            profile.last_name,
+            profile.get_primary_email_value(),
+        )
 
         return UpdateMyProfileMutation(profile=profile)
 
@@ -1360,7 +1365,12 @@ class UpdateProfileMutation(relay.ClientIDMutation):
             if sensitive_data:
                 update_sensitivedata(profile, sensitive_data)
 
-        send_profile_changes_to_keycloak(profile)
+        send_profile_changes_to_keycloak(
+            profile.user.uuid,
+            profile.first_name,
+            profile.last_name,
+            profile.get_primary_email_value(),
+        )
 
         return UpdateProfileMutation(profile=profile)
 

--- a/profiles/signals.py
+++ b/profiles/signals.py
@@ -1,9 +1,0 @@
-from django.dispatch import receiver
-
-from .keycloak_integration import send_profile_changes_to_keycloak
-from .schema import profile_updated
-
-
-@receiver(profile_updated)
-def _profile_updated_handler(sender, instance, **kwargs):
-    send_profile_changes_to_keycloak(instance)

--- a/profiles/tests/conftest.py
+++ b/profiles/tests/conftest.py
@@ -6,7 +6,6 @@ from pytest_factoryboy import register
 
 from open_city_profile.tests.conftest import *  # noqa
 from profiles.models import _default_temporary_read_access_token_validity_duration
-from profiles.schema import profile_updated
 from profiles.tests.factories import (
     AddressDataDictFactory,
     EmailDataDictFactory,
@@ -59,13 +58,6 @@ def phone_data(primary=False):
 @pytest.fixture
 def address_data(primary=False):
     return AddressDataDictFactory(primary=primary)
-
-
-@pytest.fixture
-def profile_updated_listener(mocker):
-    profile_updated_listener = mocker.MagicMock()
-    profile_updated.connect(profile_updated_listener)
-    return profile_updated_listener
 
 
 # Register factory fixtures

--- a/profiles/tests/test_gql_claim_profile_mutation.py
+++ b/profiles/tests/test_gql_claim_profile_mutation.py
@@ -6,7 +6,6 @@ from graphql_relay.node.node import to_global_id
 
 from open_city_profile.consts import API_NOT_IMPLEMENTED_ERROR, TOKEN_EXPIRED_ERROR
 from open_city_profile.tests.asserts import assert_match_error_code
-from profiles.models import Profile
 
 from .factories import (
     ClaimTokenFactory,
@@ -17,9 +16,7 @@ from .factories import (
 from .profile_input_validation import ExistingProfileInputValidationBase
 
 
-def test_user_can_claim_claimable_profile_without_existing_profile(
-    user_gql_client, profile_updated_listener
-):
+def test_user_can_claim_claimable_profile_without_existing_profile(user_gql_client):
     profile = ProfileWithPrimaryEmailFactory(
         user=None, first_name="John", last_name="Doe"
     )
@@ -65,10 +62,6 @@ def test_user_can_claim_claimable_profile_without_existing_profile(
     profile.refresh_from_db()
     assert profile.user == user_gql_client.user
     assert profile.claim_tokens.count() == 0
-
-    profile_updated_listener.assert_called_once()
-    assert profile_updated_listener.call_args[1]["sender"] == Profile
-    assert profile_updated_listener.call_args[1]["instance"] == profile
 
 
 CLAIM_PROFILE_MUTATION = """

--- a/profiles/tests/test_gql_update_my_profile_mutation.py
+++ b/profiles/tests/test_gql_update_my_profile_mutation.py
@@ -4,7 +4,7 @@ import pytest
 from graphql_relay.node.node import to_global_id
 
 from open_city_profile.tests.asserts import assert_match_error_code
-from profiles.models import Address, Email, Phone, Profile
+from profiles.models import Address, Email, Phone
 from profiles.tests.profile_input_validation import ExistingProfileInputValidationBase
 from services.tests.factories import ServiceConnectionFactory
 from utils import keycloak
@@ -21,12 +21,7 @@ from .factories import (
 
 @pytest.mark.parametrize("with_serviceconnection", (True, False))
 def test_update_profile(
-    user_gql_client,
-    email_data,
-    profile_data,
-    service,
-    profile_updated_listener,
-    with_serviceconnection,
+    user_gql_client, email_data, profile_data, service, with_serviceconnection,
 ):
     profile = ProfileWithPrimaryEmailFactory(user=user_gql_client.user)
     if with_serviceconnection:
@@ -102,15 +97,9 @@ def test_update_profile(
     executed = user_gql_client.execute(mutation, service=service)
     if with_serviceconnection:
         assert executed["data"] == expected_data
-
-        profile_updated_listener.assert_called_once()
-        assert profile_updated_listener.call_args[1]["sender"] == Profile
-        assert profile_updated_listener.call_args[1]["instance"] == profile
     else:
         assert_match_error_code(executed, "PERMISSION_DENIED_ERROR")
         assert executed["data"]["updateMyProfile"] is None
-
-        profile_updated_listener.assert_not_called()
 
 
 def test_update_profile_without_email(user_gql_client, profile_data):

--- a/profiles/tests/test_gql_update_my_profile_mutation.py
+++ b/profiles/tests/test_gql_update_my_profile_mutation.py
@@ -5,7 +5,7 @@ from graphql_relay.node.node import to_global_id
 
 from open_city_profile.exceptions import DataConflictError
 from open_city_profile.tests.asserts import assert_match_error_code
-from profiles.models import Address, Email, Phone
+from profiles.models import Address, Email, Phone, Profile
 from profiles.tests.profile_input_validation import ExistingProfileInputValidationBase
 from services.tests.factories import ServiceConnectionFactory
 
@@ -579,12 +579,12 @@ def test_remove_all_emails_if_they_are_not_primary(user_gql_client):
     assert executed["data"] == expected_data
 
 
-def test_when_keycloak_returns_conflict_on_update_then_correct_error_code_is_produced(
+def test_when_keycloak_returns_conflict_on_update_then_correct_error_code_is_produced_and_data_remains_unmodified(
     user_gql_client, mocker
 ):
     user = user_gql_client.user
     profile = ProfileWithPrimaryEmailFactory(user=user)
-    email = profile.emails.first()
+    email = profile.emails.get()
     NEW_FIRST_NAME = "New first name"
     NEW_LAST_NAME = "New last name"
 
@@ -608,6 +608,10 @@ def test_when_keycloak_returns_conflict_on_update_then_correct_error_code_is_pro
     keycloak_mock.assert_called_once_with(
         user.uuid, NEW_FIRST_NAME, NEW_LAST_NAME, NEW_EMAIL_VALUE
     )
+    profile_afterwards = Profile.objects.get(user=user)
+    assert profile_afterwards.first_name == profile.first_name
+    assert profile_afterwards.last_name == profile.last_name
+    assert profile_afterwards.emails.get().email == email.email
 
 
 PHONES_MUTATION = """

--- a/profiles/tests/test_gql_update_profile_mutation.py
+++ b/profiles/tests/test_gql_update_profile_mutation.py
@@ -266,12 +266,12 @@ def test_changing_an_email_address_marks_it_unverified(user_gql_client, service)
     assert executed["data"] == expected_data
 
 
-def test_when_keycloak_returns_conflict_on_update_then_correct_error_code_is_produced(
+def test_when_keycloak_returns_conflict_on_update_then_correct_error_code_is_produced_and_data_remains_unmodified(
     user_gql_client, service, mocker
 ):
     user = user_gql_client.user
     profile = ProfileWithPrimaryEmailFactory(user=user)
-    email = profile.emails.first()
+    email = profile.emails.get()
     NEW_FIRST_NAME = "New first name"
     NEW_LAST_NAME = "New last name"
 
@@ -300,6 +300,10 @@ def test_when_keycloak_returns_conflict_on_update_then_correct_error_code_is_pro
     keycloak_mock.assert_called_once_with(
         user.uuid, NEW_FIRST_NAME, NEW_LAST_NAME, NEW_EMAIL_VALUE
     )
+    profile_afterwards = Profile.objects.get(user=user)
+    assert profile_afterwards.first_name == profile.first_name
+    assert profile_afterwards.last_name == profile.last_name
+    assert profile_afterwards.emails.get().email == email.email
 
 
 class TestProfileInputValidation(ExistingProfileInputValidationBase):

--- a/profiles/tests/test_gql_update_profile_mutation.py
+++ b/profiles/tests/test_gql_update_profile_mutation.py
@@ -40,7 +40,7 @@ def setup_profile_and_staff_user_to_service(
 
 @pytest.mark.parametrize("with_serviceconnection", (True, False))
 def test_staff_user_can_update_a_profile(
-    user_gql_client, service, profile_updated_listener, with_serviceconnection,
+    user_gql_client, service, with_serviceconnection,
 ):
     profile = ProfileWithPrimaryEmailFactory(first_name="Joe")
     phone = PhoneFactory(profile=profile)
@@ -155,15 +155,9 @@ def test_staff_user_can_update_a_profile(
     executed = user_gql_client.execute(query, service=service)
     if with_serviceconnection:
         assert executed["data"] == expected_data
-
-        profile_updated_listener.assert_called_once()
-        assert profile_updated_listener.call_args[1]["sender"] == Profile
-        assert profile_updated_listener.call_args[1]["instance"] == profile
     else:
         assert_match_error_code(executed, "PERMISSION_DENIED_ERROR")
         assert executed["data"]["updateProfile"] is None
-
-        profile_updated_listener.assert_not_called()
 
 
 EMAILS_MUTATION = """

--- a/profiles/tests/test_profile_changes_to_keycloak.py
+++ b/profiles/tests/test_profile_changes_to_keycloak.py
@@ -4,22 +4,27 @@ from open_city_profile.exceptions import DataConflictError
 from profiles.keycloak_integration import send_profile_changes_to_keycloak
 from utils import keycloak
 
-from .factories import ProfileFactory, ProfileWithPrimaryEmailFactory
-
 
 @pytest.fixture(autouse=True)
 def setup_profile_change_handling(keycloak_setup):
     return keycloak_setup
 
 
-def test_do_nothing_if_profile_has_no_user(mocker):
+USER_ID = "user id"
+FIRST_NAME = "First name"
+LAST_NAME = "Last name"
+EMAIL = "email@email.example"
+
+
+def test_do_nothing_if_user_id_is_not_provided(mocker):
     mocked_get_user = mocker.patch.object(keycloak.KeycloakAdminClient, "get_user")
     mocked_update_user = mocker.patch.object(
         keycloak.KeycloakAdminClient, "update_user"
     )
-    profile = ProfileFactory(user=None)
 
-    send_profile_changes_to_keycloak(profile)
+    send_profile_changes_to_keycloak(
+        None, FIRST_NAME, LAST_NAME, EMAIL,
+    )
 
     mocked_get_user.assert_not_called()
     mocked_update_user.assert_not_called()
@@ -35,17 +40,17 @@ def test_do_nothing_if_user_is_not_found_in_keycloak(mocker):
         keycloak.KeycloakAdminClient, "update_user"
     )
 
-    profile = ProfileFactory()
-
-    send_profile_changes_to_keycloak(profile)
+    send_profile_changes_to_keycloak(
+        "not found user id", FIRST_NAME, LAST_NAME, EMAIL,
+    )
 
     mocked_update_user.assert_not_called()
 
 
 def test_changed_names_are_sent_to_keycloak(mocker):
     new_values = {
-        "firstName": "New first name",
-        "lastName": "New last name",
+        "firstName": FIRST_NAME,
+        "lastName": LAST_NAME,
         "email": None,
     }
 
@@ -58,13 +63,11 @@ def test_changed_names_are_sent_to_keycloak(mocker):
         keycloak.KeycloakAdminClient, "update_user"
     )
 
-    profile = ProfileFactory(
-        first_name=new_values["firstName"], last_name=new_values["lastName"]
+    send_profile_changes_to_keycloak(
+        USER_ID, new_values["firstName"], new_values["lastName"], None,
     )
-    user_id = profile.user.uuid
-    send_profile_changes_to_keycloak(profile)
 
-    mocked_update_user.assert_called_once_with(user_id, new_values)
+    mocked_update_user.assert_called_once_with(USER_ID, new_values)
 
 
 @pytest.mark.parametrize("send_verify_email_succeeds", (True, False))
@@ -72,9 +75,9 @@ def test_changing_email_causes_it_to_be_marked_unverified(
     mocker, send_verify_email_succeeds
 ):
     new_values = {
-        "firstName": "First name",
-        "lastName": "Last name",
-        "email": "new@email.example",
+        "firstName": FIRST_NAME,
+        "lastName": LAST_NAME,
+        "email": EMAIL,
         "emailVerified": False,
     }
 
@@ -98,19 +101,16 @@ def test_changing_email_causes_it_to_be_marked_unverified(
         else Exception("send_verify_email failed"),
     )
 
-    profile = ProfileFactory(
-        first_name=new_values["firstName"], last_name=new_values["lastName"]
+    send_profile_changes_to_keycloak(
+        USER_ID, new_values["firstName"], new_values["lastName"], new_values["email"],
     )
-    profile.emails.create(email=new_values["email"], primary=True)
-    user_id = profile.user.uuid
-    send_profile_changes_to_keycloak(profile)
 
-    mocked_update_user.assert_called_once_with(user_id, new_values)
-    mocked_send_verify_email.assert_called_once_with(user_id)
+    mocked_update_user.assert_called_once_with(USER_ID, new_values)
+    mocked_send_verify_email.assert_called_once_with(USER_ID)
 
 
 def test_if_there_are_no_changes_then_nothing_is_sent_to_keycloak(mocker):
-    values = {"firstName": "First name", "lastName": "Last name"}
+    values = {"firstName": FIRST_NAME, "lastName": LAST_NAME}
 
     mocker.patch.object(
         keycloak.KeycloakAdminClient, "get_user", return_value=values,
@@ -119,23 +119,20 @@ def test_if_there_are_no_changes_then_nothing_is_sent_to_keycloak(mocker):
         keycloak.KeycloakAdminClient, "update_user"
     )
 
-    profile = ProfileFactory(
-        first_name=values["firstName"], last_name=values["lastName"]
+    send_profile_changes_to_keycloak(
+        USER_ID, values["firstName"], values["lastName"], None,
     )
-    send_profile_changes_to_keycloak(profile)
 
     mocked_update_user.assert_not_called()
 
 
 def test_when_update_causes_a_conflict_then_data_conflict_error_is_raised(mocker):
-    profile = ProfileWithPrimaryEmailFactory()
-
     mocker.patch.object(
         keycloak.KeycloakAdminClient,
         "get_user",
         return_value={
-            "firstName": profile.first_name,
-            "lastName": profile.last_name,
+            "firstName": FIRST_NAME,
+            "lastName": LAST_NAME,
             "email": "old@email.example",
         },
     )
@@ -147,4 +144,6 @@ def test_when_update_causes_a_conflict_then_data_conflict_error_is_raised(mocker
     )
 
     with pytest.raises(DataConflictError):
-        send_profile_changes_to_keycloak(profile)
+        send_profile_changes_to_keycloak(
+            USER_ID, FIRST_NAME, LAST_NAME, EMAIL,
+        )


### PR DESCRIPTION
Previously the profile updating logic was like this:

- Modify own database (including closing the transaction)
- Send changed profile data to Keycloak
- If previous step fails, return an error to caller (but own database was already changed and it's left like that)

The logic after this PR is:

- Modify profile models in memory
- Send changed profile data to Keycloak
- If previous step fails, return an error to caller
- If we get here, persist the models to own database

The profile data updating logic needed quite a big change. This is built gradually in the several commits. There are also some other improvements, like better handling of invalid Relay global ids. New tests were also added for cases that were discovered to be untested before.