### PR TITLE
Application logging settings. Some logging to gdpr query.

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -51,6 +51,12 @@ It's possible to configure open-city-profile to communicate with a https://www.k
 - `KEYCLOAK_CLIENT_ID`: Authentication to the Keycloak instance happens https://www.keycloak.org/docs/latest/server_development/#authenticate-with-a-service-account[using a service account]. This is the client id.
 - `KEYCLOAK_CLIENT_SECRET`: ...and this is the client secret.
 
+== Application logging
+
+Application logs are output to stderr.
+
+- `OPEN_CITY_PROFILE_LOG_LEVEL`: sets logging level. Use any string representation of a https://docs.python.org/dev/library/logging.html#levels[Python logging level]. Default is "DEBUG" if Django's `DEBUG` setting is on, otherwise it's "INFO".
+
 == Audit events
 
 Profile data access produces audit events. Audit events may be output to multiple destinations. The destinations can be enabled individually. By default all outputs are disabled.

--- a/open_city_profile/logging.py
+++ b/open_city_profile/logging.py
@@ -1,0 +1,6 @@
+import logging
+import time
+
+
+class UtcFormatter(logging.Formatter):
+    converter = time.gmtime

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -339,11 +339,39 @@ else:
         "stream": stdout,
     }
 
+_loggers = {
+    "audit": {"handlers": ["audit"], "level": "INFO", "propagate": True},
+}
+_loggers.update(
+    (
+        app_name,
+        {
+            "handlers": ["console"],
+            "level": "DEBUG" if DEBUG else "INFO",
+            "propagate": True,
+        },
+    )
+    for app_name in (
+        "audit_log",
+        "open_city_profile",
+        "profiles",
+        "services",
+        "users",
+        "utils",
+    )
+)
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "handlers": {"audit": _audit_log_handler},
-    "loggers": {"audit": {"handlers": ["audit"], "level": "INFO", "propagate": True}},
+    "formatters": {
+        "simple": {"format": "%(name)s %(asctime)s %(levelname)s %(message)s"},
+    },
+    "handlers": {
+        "audit": _audit_log_handler,
+        "console": {"class": "logging.StreamHandler", "formatter": "simple"},
+    },
+    "loggers": _loggers,
 }
 
 GDPR_AUTH_CALLBACK_URL = env("GDPR_AUTH_CALLBACK_URL")

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -47,6 +47,7 @@ env = environ.Env(
     AUDIT_LOG_TO_LOGGER_ENABLED=(bool, False),
     AUDIT_LOG_LOGGER_FILENAME=(str, ""),
     AUDIT_LOG_TO_DB_ENABLED=(bool, False),
+    OPEN_CITY_PROFILE_LOG_LEVEL=(str, None),
     ENABLE_GRAPHIQL=(bool, False),
     FORCE_SCRIPT_NAME=(str, ""),
     CSRF_COOKIE_NAME=(str, ""),
@@ -339,18 +340,15 @@ else:
         "stream": stdout,
     }
 
+_log_level = env("OPEN_CITY_PROFILE_LOG_LEVEL")
+if not _log_level:
+    _log_level = "DEBUG" if DEBUG else "INFO"
+
 _loggers = {
     "audit": {"handlers": ["audit"], "level": "INFO", "propagate": True},
 }
 _loggers.update(
-    (
-        app_name,
-        {
-            "handlers": ["console"],
-            "level": "DEBUG" if DEBUG else "INFO",
-            "propagate": True,
-        },
-    )
+    (app_name, {"handlers": ["console"], "level": _log_level, "propagate": True})
     for app_name in (
         "audit_log",
         "open_city_profile",

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -365,7 +365,11 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "simple": {"format": "%(name)s %(asctime)s %(levelname)s %(message)s"},
+        "simple": {
+            "format": "%(name)s %(asctime)s.%(msecs)03dZ %(levelname)s %(message)s",
+            "()": "open_city_profile.logging.UtcFormatter",
+            "datefmt": "%Y-%m-%dT%H:%M:%S",
+        },
     },
     "handlers": {
         "audit": _audit_log_handler,

--- a/profiles/connected_services.py
+++ b/profiles/connected_services.py
@@ -1,3 +1,5 @@
+import logging
+
 import requests
 
 from open_city_profile.exceptions import (
@@ -8,12 +10,17 @@ from open_city_profile.exceptions import (
 from open_city_profile.oidc import TunnistamoTokenExchange
 from utils.auth import BearerAuth
 
+logger = logging.getLogger(__name__)
+
 
 def _check_service_gdpr_query_configuration(service_connections):
     for service_connection in service_connections:
         service = service_connection.service
 
         if not service_connection.get_gdpr_url() or not service.gdpr_query_scope:
+            logger.error(
+                "GDPR URL or GDPR query scope missing for service %s", service.name
+            )
             raise ConnectedServiceDataQueryFailedError(
                 f"Connected service: {service.name} does not have an API for querying data."
             )
@@ -22,32 +29,55 @@ def _check_service_gdpr_query_configuration(service_connections):
 def download_connected_service_data(profile, authorization_code):
     service_connections = profile.effective_service_connections_qs().all()
     if not service_connections:
+        logger.debug("No service connections for profile %s", profile.id)
         return []
 
     _check_service_gdpr_query_configuration(service_connections)
 
+    logger.debug("Downloading connected service data for profile %s", profile.id)
+
     tte = TunnistamoTokenExchange()
     api_tokens = tte.fetch_api_tokens(authorization_code)
+    logger.debug("API Tokens: %s", api_tokens)
 
     external_data = []
 
     for service_connection in service_connections:
         service = service_connection.service
+        logger.debug("Starting GDPR query for service %s", service.name)
 
         api_identifier = service.gdpr_query_scope.rsplit(".", 1)[0]
         api_token = api_tokens.get(api_identifier, "")
 
         if not api_token:
+            logger.error(
+                "API Token missing for service %s (profile %s)",
+                service.name,
+                profile.id,
+            )
             raise MissingGDPRApiTokenError(
                 f"Couldn't fetch an API token for service {service.name}."
             )
 
         try:
             url = service_connection.get_gdpr_url()
+            logger.debug("GDPR URL: %s", url)
             response = requests.get(url, auth=BearerAuth(api_token), timeout=5)
+            logger.debug(
+                "Response status code: %s, headers: %s, body: %s",
+                response.status_code,
+                response.headers,
+                response.text,
+            )
             response.raise_for_status()
             service_connection_data = response.json()
-        except requests.RequestException:
+        except requests.RequestException as e:
+            logger.error(
+                "Invalid response for profile %s from service %s. Exception: %s.",
+                profile.id,
+                service.name,
+                e,
+            )
             raise ConnectedServiceDataQueryFailedError(
                 f"Invalid response from service {service.name}"
             )


### PR DESCRIPTION
Almost the same as in the [gdpr-query-logging](https://github.com/City-of-Helsinki/open-city-profile/tree/gdpr-query-logging) branch, but now in proper commits. Differences to the WIP branch are:

- Configure logging for all apps in this project
- Use full logger `name` instead of `module` (which would be the part after the last dot of the `name`) in the log message
- A setting for overwriting the log level