### PR TITLE
Add logging to GDPR delete functionality

### DIFF
--- a/profiles/connected_services.py
+++ b/profiles/connected_services.py
@@ -1,13 +1,21 @@
 import logging
+from dataclasses import dataclass
+from json import JSONDecodeError
+from typing import List
 
 import requests
 
+from open_city_profile.consts import (
+    SERVICE_GDPR_API_REQUEST_ERROR,
+    SERVICE_GDPR_API_UNKNOWN_ERROR,
+)
 from open_city_profile.exceptions import (
     ConnectedServiceDataQueryFailedError,
     ConnectedServiceDeletionNotAllowedError,
     MissingGDPRApiTokenError,
 )
 from open_city_profile.oidc import TunnistamoTokenExchange
+from services.models import Service
 from utils.auth import BearerAuth
 
 logger = logging.getLogger(__name__)
@@ -88,6 +96,126 @@ def download_connected_service_data(profile, authorization_code):
     return external_data
 
 
+@dataclass
+class DeleteGdprDataErrorMessage:
+    lang: str
+    text: str
+
+
+@dataclass
+class DeleteGdprDataError:
+    code: str
+    message: List[DeleteGdprDataErrorMessage]
+
+
+@dataclass
+class DeleteGdprDataResult:
+    service: Service
+    dry_run: bool
+    success: bool
+    errors: List[DeleteGdprDataError]
+
+
+def _validate_gdpr_api_errors(errors):
+    try:
+        iter(errors)
+    except TypeError:
+        return False
+
+    expected_keys = {"code", "message"}
+    for error in errors:
+        if set(error.keys()) != expected_keys:
+            return False
+        if not error.get("code") or not isinstance(error["code"], str):
+            return False
+        if not error.get("message") or not isinstance(error["message"], dict):
+            return False
+
+        for key, value in error["message"].items():
+            if not key or not isinstance(value, str):
+                return False
+
+    return True
+
+
+def _convert_gdpr_api_errors(errors) -> List[DeleteGdprDataError]:
+    """Converts errors from the GDPR API to a list of DeleteGdprDataErrors"""
+    converted_errors = []
+    for error in errors:
+        converted_error = DeleteGdprDataError(code=error["code"], message=[])
+        for lang, text in error["message"].items():
+            converted_error.message.append(
+                DeleteGdprDataErrorMessage(lang=lang, text=text)
+            )
+        converted_errors.append(converted_error)
+
+    return converted_errors
+
+
+def _add_error_to_result(result, code, message):
+    result.errors.append(
+        DeleteGdprDataError(
+            code=code, message=[DeleteGdprDataErrorMessage(lang="en", text=message)]
+        )
+    )
+
+    return result
+
+
+def _delete_service_data(
+    service_connection, api_token: str, dry_run=False
+) -> DeleteGdprDataResult:
+    """Delete service specific GDPR data by profile.
+
+    API token needs to be for a user that can access information for the related
+    profile on the related GDPR API.
+
+    Dry run parameter can be used for asking the service if delete is possible.
+
+    The errors content from the service is returned if the service provides a JSON
+    response with an "errors" key containing valid error content.
+    """
+    result = DeleteGdprDataResult(
+        service=service_connection.service, dry_run=dry_run, success=False, errors=[],
+    )
+
+    url = service_connection.get_gdpr_url()
+
+    data = {}
+    if dry_run:
+        data["dry_run"] = "true"
+
+    try:
+        response = requests.delete(
+            url, auth=BearerAuth(api_token), timeout=5, params=data
+        )
+    except requests.RequestException:
+        return _add_error_to_result(
+            result,
+            SERVICE_GDPR_API_REQUEST_ERROR,
+            "Error when making a request to the GDPR URL of the service",
+        )
+
+    if response.status_code == 204:
+        result.success = True
+        return result
+
+    if response.status_code in [403, 500]:
+        try:
+            errors_from_the_service = response.json().get("errors")
+            if _validate_gdpr_api_errors(errors_from_the_service):
+                result.errors = _convert_gdpr_api_errors(errors_from_the_service)
+                return result
+        except JSONDecodeError:
+            pass
+
+    return _add_error_to_result(
+        result,
+        SERVICE_GDPR_API_UNKNOWN_ERROR,
+        "Unknown error occurred when trying to remove data from the service",
+    )
+
+
 def _delete_service_connection_and_service_data(
     service_connections, api_tokens, dry_run=False
 ):
@@ -98,9 +226,7 @@ def _delete_service_connection_and_service_data(
         api_identifier = service.gdpr_delete_scope.rsplit(".", 1)[0]
         api_token = api_tokens.get(api_identifier, "")
 
-        result = service_connection.delete_gdpr_data(
-            api_token=api_token, dry_run=dry_run
-        )
+        result = _delete_service_data(service_connection, api_token, dry_run=dry_run)
         if result.success and not dry_run:
             service_connection.delete()
 

--- a/services/models.py
+++ b/services/models.py
@@ -1,21 +1,12 @@
 import urllib.parse
-from dataclasses import dataclass
-from json import JSONDecodeError
 from string import Template
-from typing import List
 
-import requests
 from adminsortable.models import SortableMixin
 from django.db import models
 from django.db.models import Max, Q
 from enumfields import EnumField
 from parler.models import TranslatableModel, TranslatedFields
 
-from open_city_profile.consts import (
-    SERVICE_GDPR_API_REQUEST_ERROR,
-    SERVICE_GDPR_API_UNKNOWN_ERROR,
-)
-from utils.auth import BearerAuth
 from utils.models import SerializableMixin
 
 from .enums import ServiceType
@@ -144,72 +135,6 @@ class ServiceClientId(models.Model):
     client_id = models.CharField(max_length=256, null=False, blank=False, unique=True)
 
 
-def _validate_gdpr_api_errors(errors):
-    try:
-        iter(errors)
-    except TypeError:
-        return False
-
-    expected_keys = {"code", "message"}
-    for error in errors:
-        if set(error.keys()) != expected_keys:
-            return False
-        if not error.get("code") or not isinstance(error["code"], str):
-            return False
-        if not error.get("message") or not isinstance(error["message"], dict):
-            return False
-
-        for key, value in error["message"].items():
-            if not key or not isinstance(value, str):
-                return False
-
-    return True
-
-
-@dataclass
-class DeleteGdprDataErrorMessage:
-    lang: str
-    text: str
-
-
-@dataclass
-class DeleteGdprDataError:
-    code: str
-    message: List[DeleteGdprDataErrorMessage]
-
-
-@dataclass
-class DeleteGdprDataResult:
-    service: Service
-    dry_run: bool
-    success: bool
-    errors: List[DeleteGdprDataError]
-
-
-def _convert_gdpr_api_errors(errors) -> List[DeleteGdprDataError]:
-    """Converts errors from the GDPR API to a list of DeleteGdprDataErrors"""
-    converted_errors = []
-    for error in errors:
-        converted_error = DeleteGdprDataError(code=error["code"], message=[])
-        for lang, text in error["message"].items():
-            converted_error.message.append(
-                DeleteGdprDataErrorMessage(lang=lang, text=text)
-            )
-        converted_errors.append(converted_error)
-
-    return converted_errors
-
-
-def _add_error_to_result(result, code, message):
-    result.errors.append(
-        DeleteGdprDataError(
-            code=code, message=[DeleteGdprDataErrorMessage(lang="en", text=message)]
-        )
-    )
-
-    return result
-
-
 class ServiceConnection(SerializableMixin):
     profile = models.ForeignKey(
         "profiles.Profile", on_delete=models.CASCADE, related_name="service_connections"
@@ -234,54 +159,3 @@ class ServiceConnection(SerializableMixin):
 
     def get_gdpr_url(self):
         return self.service.get_gdpr_url_for_profile(self.profile)
-
-    def delete_gdpr_data(self, api_token: str, dry_run=False) -> DeleteGdprDataResult:
-        """Delete service specific GDPR data by profile.
-
-        API token needs to be for a user that can access information for the related
-        profile on the related GDPR API.
-
-        Dry run parameter can be used for asking the service if delete is possible.
-
-        The errors content from the service is returned if the service provides a JSON
-        response with an "errors" key containing valid error content.
-        """
-        result = DeleteGdprDataResult(
-            service=self.service, dry_run=dry_run, success=False, errors=[],
-        )
-
-        url = self.get_gdpr_url()
-
-        data = {}
-        if dry_run:
-            data["dry_run"] = "true"
-
-        try:
-            response = requests.delete(
-                url, auth=BearerAuth(api_token), timeout=5, params=data
-            )
-        except requests.RequestException:
-            return _add_error_to_result(
-                result,
-                SERVICE_GDPR_API_REQUEST_ERROR,
-                "Error when making a request to the GDPR URL of the service",
-            )
-
-        if response.status_code == 204:
-            result.success = True
-            return result
-
-        if response.status_code in [403, 500]:
-            try:
-                errors_from_the_service = response.json().get("errors")
-                if _validate_gdpr_api_errors(errors_from_the_service):
-                    result.errors = _convert_gdpr_api_errors(errors_from_the_service)
-                    return result
-            except JSONDecodeError:
-                pass
-
-        return _add_error_to_result(
-            result,
-            SERVICE_GDPR_API_UNKNOWN_ERROR,
-            "Unknown error occurred when trying to remove data from the service",
-        )

--- a/services/tests/test_models.py
+++ b/services/tests/test_models.py
@@ -146,41 +146,6 @@ def test_remove_service_gdpr_data_fail(profile, service, requests_mock):
     assert real_result.success is False
 
 
-@pytest.mark.parametrize("service__gdpr_url", [GDPR_URL])
-@pytest.mark.parametrize(
-    "error_content",
-    [
-        {"unknown_key": "data"},
-        {"message": {"en": "No code"}},
-        {"code": "no message"},
-        {"code": None, "message": None},
-        {"code": None, "message": {}},
-        {"code": "ERROR_CODE", "message": None},
-        {"code": "ERROR_CODE", "message": {}},
-        {"code": "ERROR_CODE", "message": {"en": None}},
-        {"code": "ERROR_CODE", "message": {"": "Message with empty key"}},
-        {"code": 123, "message": {"en": "Code is wrong type"}},
-        {"code": "", "message": {"en": "Code is empty"}},
-        {"code": "ERROR_CODE", "message": "Message not an object"},
-    ],
-)
-def test_invalid_error_messages_from_service_gdpr_api_results_in_unknown_error(
-    profile, service, requests_mock, error_content
-):
-    requests_mock.delete(
-        f"{GDPR_URL}{profile.pk}",
-        json={"errors": [error_content]},
-        status_code=403,
-        request_headers={"authorization": "Bearer token"},
-    )
-
-    service_connection = ServiceConnectionFactory(profile=profile, service=service)
-
-    result = service_connection.delete_gdpr_data(api_token="token")
-
-    assert result.errors[0].code == "SERVICE_GDPR_API_UNKNOWN_ERROR"
-
-
 @pytest.mark.parametrize(
     "service__gdpr_url, expected",
     [


### PR DESCRIPTION
First moved the service data deletion code to `connected_services` module, where the GDPR query code already was and the deletion code also partially. Tests required some adjustment to enable that move.