### PR TITLE
Handle GDPR API responses according to the specs

### DIFF
--- a/profiles/connected_services.py
+++ b/profiles/connected_services.py
@@ -78,7 +78,11 @@ def download_connected_service_data(profile, authorization_code):
                 response.text,
             )
             response.raise_for_status()
-            service_connection_data = response.json()
+
+            if response.status_code == 200:
+                service_connection_data = response.json()
+            else:
+                service_connection_data = {}
         except requests.RequestException as e:
             logger.error(
                 "Invalid GDPR query response for profile %s from service %s. Exception: %s.",

--- a/profiles/tests/gdpr/test_gql_download_my_profile_query.py
+++ b/profiles/tests/gdpr/test_gql_download_my_profile_query.py
@@ -221,8 +221,9 @@ def test_user_can_download_profile_with_connected_services_using_correct_api_tok
     assert SERVICE_DATA_2 in response_data
 
 
+@pytest.mark.parametrize("service_response", ({"json": {}}, {"status_code": 204}))
 def test_empty_data_from_connected_service_is_not_included_in_response(
-    user_gql_client, service_1, gdpr_api_tokens, mocker, requests_mock
+    service_response, user_gql_client, service_1, gdpr_api_tokens, mocker, requests_mock
 ):
     mocker.patch.object(
         TunnistamoTokenExchange, "fetch_api_tokens", return_value=gdpr_api_tokens
@@ -231,7 +232,7 @@ def test_empty_data_from_connected_service_is_not_included_in_response(
     profile = ProfileFactory(user=user_gql_client.user)
     service_connection = ServiceConnectionFactory(profile=profile, service=service_1)
 
-    requests_mock.get(service_connection.get_gdpr_url(), json={})
+    requests_mock.get(service_connection.get_gdpr_url(), **service_response)
 
     executed = user_gql_client.execute(DOWNLOAD_MY_PROFILE_MUTATION)
 

--- a/profiles/tests/gdpr/test_gql_download_my_profile_query.py
+++ b/profiles/tests/gdpr/test_gql_download_my_profile_query.py
@@ -283,8 +283,14 @@ def test_api_tokens_missing(user_gql_client, service_1, mocker):
     assert_match_error_code(executed, MISSING_GDPR_API_TOKEN_ERROR)
 
 
+@pytest.mark.parametrize("service_status_code", (401, 403, 404, 500))
 def test_when_service_fails_to_return_data_then_error_is_returned(
-    user_gql_client, service_1, gdpr_api_tokens, mocker, requests_mock
+    service_status_code,
+    user_gql_client,
+    service_1,
+    gdpr_api_tokens,
+    mocker,
+    requests_mock,
 ):
     mocker.patch.object(
         TunnistamoTokenExchange, "fetch_api_tokens", return_value=gdpr_api_tokens
@@ -293,7 +299,9 @@ def test_when_service_fails_to_return_data_then_error_is_returned(
     profile = ProfileFactory(user=user_gql_client.user)
     service_connection = ServiceConnectionFactory(profile=profile, service=service_1)
 
-    requests_mock.get(service_connection.get_gdpr_url(), status_code=403)
+    requests_mock.get(
+        service_connection.get_gdpr_url(), status_code=service_status_code
+    )
 
     executed = user_gql_client.execute(DOWNLOAD_MY_PROFILE_MUTATION)
 


### PR DESCRIPTION
The only missing part was that for the data queries, `204` responses with _no content_ weren't handled correctly. The (empty) content was tried to be parsed as JSON, which caused and exception, which interrupted the whole data download request, causing an error to go all they way to the original requester.