### PR TITLE
HP-2191 | fix: settings primary email shouldn't fail on duplicate emails

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -1142,12 +1142,19 @@ class CreateOrUpdateUserProfileMutationBase:
         email_address = primary_email_input["email"]
         verified = primary_email_input.get("verified", False)
 
-        email, email_created = profile.emails.get_or_create(
-            email=email_address,
-            defaults={"email_type": EmailType.NONE, "verified": verified},
-        )
-
-        profile.emails.exclude(pk=email.pk).filter(primary=True).update(primary=False)
+        email = profile.emails.filter(email=email_address).first()
+        if email:
+            profile.emails.exclude(pk=email.pk).filter(primary=True).update(
+                primary=False
+            )
+        else:
+            profile.emails.filter(primary=True).update(primary=False)
+            email = profile.emails.create(
+                email=email_address,
+                email_type=EmailType.NONE,
+                primary=True,
+                verified=verified,
+            )
 
         if not email.primary or email.verified is not verified:
             email.primary = True

--- a/profiles/tests/test_gql_create_or_update_user_profile_mutation.py
+++ b/profiles/tests/test_gql_create_or_update_user_profile_mutation.py
@@ -47,6 +47,7 @@ def execute_mutation(input_data, gql_client):
 def execute_successful_mutation(input_data, gql_client):
     executed = execute_mutation(input_data, gql_client)
 
+    assert "errors" not in executed
     global_profile_id = executed["data"]["prof"]["profile"]["id"]
     profile_id = uuid.UUID(from_global_id(global_profile_id)[1])
 


### PR DESCRIPTION
When a user has updated their email e.g. using `updateMyProfile` mutation, there's no check for duplicate emails. Primary email update coming e.g. keycloak shouldn't fail if there's duplicate emails. Instead, using the first matching email should be enough.
