### PR TITLE
HP-2196 | Hide national identification in Django admin

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -91,8 +91,9 @@ class AddressAdminInline(admin.StackedInline):
 
 class VerifiedPersonalInformationAdminInline(admin.StackedInline):
     model = VerifiedPersonalInformation
-    exclude = ("_national_identification_number_data",)
+    exclude = ("_national_identification_number_data", "national_identification_number")
     readonly_fields = (
+        "get_national_identification_number",
         "get_permanent_address",
         "get_temporary_address",
         "get_permanent_foreign_address",
@@ -107,6 +108,10 @@ class VerifiedPersonalInformationAdminInline(admin.StackedInline):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    @admin.display(description="National identification number", boolean=True)
+    def get_national_identification_number(self, obj):
+        return bool(obj.national_identification_number)
 
     @admin.display(description="Permanent address")
     def get_permanent_address(self, obj):

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -108,6 +108,7 @@ class VerifiedPersonalInformationAdminInline(admin.StackedInline):
     def has_delete_permission(self, request, obj=None):
         return False
 
+    @admin.display(description="Permanent address")
     def get_permanent_address(self, obj):
         return "{}, {} {}\n".format(
             obj.permanent_address.street_address,
@@ -115,8 +116,7 @@ class VerifiedPersonalInformationAdminInline(admin.StackedInline):
             obj.permanent_address.post_office,
         )
 
-    get_permanent_address.short_description = "Permanent address"
-
+    @admin.display(description="Temporary address")
     def get_temporary_address(self, obj):
         return "{}, {} {}\n".format(
             obj.temporary_address.street_address,
@@ -124,16 +124,13 @@ class VerifiedPersonalInformationAdminInline(admin.StackedInline):
             obj.temporary_address.post_office,
         )
 
-    get_temporary_address.short_description = "Temporary address"
-
+    @admin.display(description="Permanent foreign address")
     def get_permanent_foreign_address(self, obj):
         return "{}, {}, {}\n".format(
             obj.permanent_foreign_address.street_address,
             obj.permanent_foreign_address.additional_address,
             obj.permanent_foreign_address.country_code,
         )
-
-    get_permanent_foreign_address.short_description = "Permanent foreign address"
 
 
 class ImportProfilesFromJsonForm(forms.Form):

--- a/users/admin.py
+++ b/users/admin.py
@@ -55,6 +55,7 @@ class UserAdmin(DjangoUserAdmin):
         fields = super().get_readonly_fields(request, obj)
         return list(fields) + ["uuid", "get_profile_uuid_link"]
 
+    @admin.display(description=_("Profile"), ordering="profile__id")
     def get_profile_uuid_link(self, obj):
         profile_id = obj.profile.id
         profile_url = reverse("admin:profiles_profile_change", args=(profile_id,))
@@ -63,9 +64,7 @@ class UserAdmin(DjangoUserAdmin):
             '<a href="{}" title="{}">{}</a>', profile_url, hint, profile_id
         )
 
-    get_profile_uuid_link.short_description = _("Profile")
-    get_profile_uuid_link.admin_order_field = "profile__id"
-
+    @admin.display(description=_("First name"))
     def get_first_name(self, obj):
         return (
             obj.first_name
@@ -73,13 +72,10 @@ class UserAdmin(DjangoUserAdmin):
             or obj.profile.verified_personal_information.first_name
         )
 
-    get_first_name.short_description = _("First name")
-
+    @admin.display(description=_("Last name"))
     def get_last_name(self, obj):
         return (
             obj.last_name
             or obj.profile.last_name
             or obj.profile.verified_personal_information.last_name
         )
-
-    get_last_name.short_description = _("Last name")


### PR DESCRIPTION
Instead of showing the actual value a boolean check-mark is displayed.

**Screenshot**
![Screenshot from 2024-02-13 17-12-47](https://github.com/City-of-Helsinki/open-city-profile/assets/225211/4e7c4224-7446-47c9-83c2-ea5bace22d97)
