### PR TITLE
 HP-2266 | fix: handle updates profile's language and contact_method fields

### DIFF
--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -175,6 +175,12 @@ def update_profile(profile, profile_data):
 
     profile_had_primary_email = bool(profile.get_primary_email_value())
 
+    if language := profile_data.pop("language", None):
+        profile.language = language.value
+
+    if contact_method := profile_data.pop("contact_method", None):
+        profile.contact_method = contact_method.value
+
     for field, value in profile_data.items():
         setattr(profile, field, value)
     profile.save()

--- a/profiles/tests/test_gql_create_my_profile_mutation.py
+++ b/profiles/tests/test_gql_create_my_profile_mutation.py
@@ -19,6 +19,8 @@ def test_normal_user_can_create_profile(
                 createMyProfile(
                     input: {
                         profile: {
+                            language: FINNISH,
+                            contactMethod: EMAIL,
                             nickname: "${nickname}",
                             addEmails: [
                                 {emailType: ${email_type}, email:"${email}", primary: ${primary}}
@@ -30,6 +32,8 @@ def test_normal_user_can_create_profile(
                     }
                 ) {
                     profile {
+                        language,
+                        contactMethod,
                         nickname,
                         emails {
                             edges {
@@ -53,6 +57,8 @@ def test_normal_user_can_create_profile(
     expected_data = {
         "createMyProfile": {
             "profile": {
+                "language": "FINNISH",
+                "contactMethod": "EMAIL",
                 "nickname": profile_data["nickname"],
                 "emails": {
                     "edges": [
@@ -79,6 +85,7 @@ def test_normal_user_can_create_profile(
         ssn=ssn,
     )
     executed = user_gql_client.execute(mutation)
+    assert "errors" not in executed
     assert executed["data"] == expected_data
 
 

--- a/profiles/tests/test_gql_create_profile_mutation.py
+++ b/profiles/tests/test_gql_create_profile_mutation.py
@@ -28,6 +28,8 @@ def test_staff_user_can_create_a_profile(
                 input: {
                     serviceType: GODCHILDREN_OF_CULTURE,
                     profile: {
+                        language: FINNISH,
+                        contactMethod: EMAIL,
                         firstName: "${first_name}",
                         lastName: "${last_name}",
 ${email_input}
@@ -42,6 +44,8 @@ ${email_input}
                 }
             ) {
                 profile {
+                    language,
+                    contactMethod,
                     firstName
                     lastName
                     phones {
@@ -97,6 +101,8 @@ ${email_input}
     expected_data = {
         "createProfile": {
             "profile": {
+                "language": "FINNISH",
+                "contactMethod": "EMAIL",
                 "firstName": "John",
                 "lastName": "Doe",
                 "phones": {


### PR DESCRIPTION
[In graphene 3](https://github.com/graphql-python/graphene/wiki/v3-release-notes#better-enum-support) when Enum's are used as an input to a field the resolver now receives the Enum member directly rather than the value. This was a breaking change that wasn't taken into account when upgrading to the new graphene major version.
