### PR TITLE
HP-2349 | feat: validate GraphQL query depth

### DIFF
--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -52,6 +52,7 @@ env = environ.Env(
     OPEN_CITY_PROFILE_LOG_LEVEL=(str, None),
     ENABLE_GRAPHIQL=(bool, False),
     ENABLE_GRAPHQL_INTROSPECTION=(bool, False),
+    GRAPHQL_QUERY_DEPTH_LIMIT=(int, 12),
     FORCE_SCRIPT_NAME=(str, ""),
     CSRF_COOKIE_NAME=(str, ""),
     CSRF_COOKIE_PATH=(str, ""),
@@ -160,6 +161,7 @@ DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL")
 ENABLE_GRAPHIQL = env("ENABLE_GRAPHIQL")
 # Enable GraphQL introspection queries, enabled automatically if DEBUG=True
 ENABLE_GRAPHQL_INTROSPECTION = env("ENABLE_GRAPHQL_INTROSPECTION")
+GRAPHQL_QUERY_DEPTH_LIMIT = env("GRAPHQL_QUERY_DEPTH_LIMIT")
 
 INSTALLED_APPS = [
     "helusers.apps.HelusersConfig",

--- a/open_city_profile/tests/graphql_test_helpers.py
+++ b/open_city_profile/tests/graphql_test_helpers.py
@@ -74,7 +74,11 @@ query {
 
 
 def do_graphql_call(
-    live_server, request_auth=None, query=_QUERY, extra_request_args=None
+    live_server,
+    request_auth=None,
+    query=_QUERY,
+    extra_request_args=None,
+    expected_status=200,
 ):
     if extra_request_args is None:
         extra_request_args = {}
@@ -96,7 +100,7 @@ def do_graphql_call(
         response = requests.post(url, json=payload, **request_args)
 
     assert (
-        response.status_code == 200
+        response.status_code == expected_status
     ), f"Status: {response.status_code}. Body:\n{response.text}"
 
     body = response.json()
@@ -113,6 +117,7 @@ def do_graphql_call_as_user(
     extra_claims=None,
     query=_QUERY,
     extra_request_args=None,
+    expected_status=200,
 ):
     if extra_request_args is None:
         extra_request_args = {}
@@ -138,4 +143,5 @@ def do_graphql_call_as_user(
         BearerTokenAuth(extra_claims=claims),
         query=query,
         extra_request_args=extra_request_args,
+        expected_status=expected_status,
     )

--- a/open_city_profile/tests/test_graphql_api_schema.py
+++ b/open_city_profile/tests/test_graphql_api_schema.py
@@ -1,32 +1,7 @@
-import pytest
-import requests
-from graphql import get_introspection_query, print_schema
+from graphql import print_schema
 
 
 def test_graphql_schema_matches_the_reference(gql_schema, snapshot):
     actual_schema = print_schema(gql_schema)
 
     snapshot.assert_match(actual_schema)
-
-
-@pytest.mark.parametrize("enabled", [True, False])
-def test_graphql_schema_introspection_can_be_disabled(live_server, settings, enabled):
-    settings.ENABLE_GRAPHQL_INTROSPECTION = enabled
-    url = live_server.url + "/graphql/"
-    payload = {
-        "query": get_introspection_query(),
-    }
-
-    response = requests.post(url, json=payload)
-
-    body = response.json()
-    if enabled:
-        assert response.status_code == 200
-        assert "errors" not in body
-        assert "__schema" in body["data"]
-    else:
-        assert response.status_code == 400
-        assert "data" not in body
-        error = body["errors"][0]["message"]
-        assert "__schema" in error
-        assert "introspection is disabled" in error

--- a/open_city_profile/tests/test_graphql_api_validation_rules.py
+++ b/open_city_profile/tests/test_graphql_api_validation_rules.py
@@ -1,0 +1,68 @@
+import pytest
+from graphql import get_introspection_query
+
+from open_city_profile.tests.graphql_test_helpers import (
+    do_graphql_call,
+    do_graphql_call_as_user,
+)
+
+
+@pytest.mark.parametrize(
+    "enabled, expected_status",
+    [pytest.param(True, 200, id="enabled"), pytest.param(False, 400, id="disabled")],
+)
+def test_graphql_schema_introspection_can_be_disabled(
+    live_server, settings, enabled, expected_status
+):
+    settings.ENABLE_GRAPHQL_INTROSPECTION = enabled
+
+    data, errors = do_graphql_call(
+        live_server, query=get_introspection_query(), expected_status=expected_status
+    )
+
+    if enabled:
+        assert errors is None
+        assert "__schema" in data
+    else:
+        assert data is None
+        error = errors[0]["message"]
+        assert "__schema" in error
+        assert "introspection is disabled" in error
+
+
+@pytest.mark.parametrize(
+    "depth_limit, expected_status, success",
+    [
+        pytest.param(4, 200, True, id="within-limit"),
+        pytest.param(3, 400, False, id="over-limit"),
+    ],
+)
+def test_graphql_query_depth_can_be_limited(
+    live_server, settings, user, depth_limit, expected_status, success
+):
+    settings.GRAPHQL_QUERY_DEPTH_LIMIT = depth_limit
+    query = """
+        {
+            myProfile {
+                emails {
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    """
+
+    data, errors = do_graphql_call_as_user(
+        live_server, user, query=query, expected_status=expected_status
+    )
+
+    if success:
+        assert errors is None
+        assert "myProfile" in data
+    else:
+        assert data is None
+        error = errors[0]["message"]
+        assert "exceeds maximum operation depth" in error


### PR DESCRIPTION
This PR adds maximum graphql query depth validation (default: 12).