### PR TITLE
feat: disable query suggestions

### DIFF
--- a/open_city_profile/apps.py
+++ b/open_city_profile/apps.py
@@ -9,6 +9,7 @@ class OpenCityProfileConfig(AppConfig):
 
     def ready(self) -> None:
         import open_city_profile.checks  # noqa: F401
+        import open_city_profile.signals  # noqa: F401
 
 
 class OpenCityProfileAdminConfig(AdminConfig):

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -7,6 +7,7 @@ import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from open_city_profile import __version__
+from open_city_profile.utils import enable_graphql_query_suggestion
 
 checkout_dir = environ.Path(__file__) - 2
 assert os.path.exists(checkout_dir("manage.py"))
@@ -167,6 +168,10 @@ DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL")
 ENABLE_GRAPHIQL = env("ENABLE_GRAPHIQL")
 # Enable GraphQL introspection queries, enabled automatically if DEBUG=True
 ENABLE_GRAPHQL_INTROSPECTION = env("ENABLE_GRAPHQL_INTROSPECTION")
+
+if not ENABLE_GRAPHQL_INTROSPECTION:
+    enable_graphql_query_suggestion(False)
+
 GRAPHQL_QUERY_DEPTH_LIMIT = env("GRAPHQL_QUERY_DEPTH_LIMIT")
 
 INSTALLED_APPS = [

--- a/open_city_profile/signals.py
+++ b/open_city_profile/signals.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+from django.core.signals import setting_changed
+from django.dispatch import receiver
+
+from open_city_profile.utils import enable_graphql_query_suggestion
+
+
+@receiver(setting_changed)
+def reload_graphql_introspection_settings(setting, **kwargs):
+    if setting == "ENABLE_GRAPHQL_INTROSPECTION":
+        enable_graphql_query_suggestion(settings.ENABLE_GRAPHQL_INTROSPECTION)

--- a/open_city_profile/tests/test_graphql_api_validation_rules.py
+++ b/open_city_profile/tests/test_graphql_api_validation_rules.py
@@ -66,3 +66,25 @@ def test_graphql_query_depth_can_be_limited(
         assert data is None
         error = errors[0]["message"]
         assert "exceeds maximum operation depth" in error
+
+
+@pytest.mark.parametrize(
+    "enabled", [pytest.param(True, id="enabled"), pytest.param(False, id="disabled")]
+)
+def test_graphql_query_suggestions_can_be_disabled(live_server, settings, enabled):
+    error_string = "Did you mean 'sdl'?"
+    query = """
+    query {
+        _service {
+            sd
+        }
+    }"""
+    settings.ENABLE_GRAPHQL_INTROSPECTION = enabled
+
+    data, errors = do_graphql_call(live_server, query=query, expected_status=400)
+
+    error = errors[0]["message"]
+    if enabled:
+        assert error_string in error
+    else:
+        assert error_string not in error

--- a/open_city_profile/utils.py
+++ b/open_city_profile/utils.py
@@ -1,0 +1,20 @@
+from graphql.pyutils import did_you_mean
+
+_original_max_length = None
+
+
+def enable_graphql_query_suggestion(enable: bool):
+    """Enable or disable graphql query suggestions.
+
+    Adapted from: https://github.com/graphql-python/graphql-core/issues/97#issuecomment-642967670
+    """
+    global _original_max_length
+
+    if not _original_max_length:
+        # Original value is stored mainly to be able to toggle it in tests.
+        _original_max_length = did_you_mean.__globals__["MAX_LENGTH"]
+
+    if enable:
+        did_you_mean.__globals__["MAX_LENGTH"] = _original_max_length
+    else:
+        did_you_mean.__globals__["MAX_LENGTH"] = 0


### PR DESCRIPTION
When graphql introspection is disabled,	query suggestion feature	should also be disabled. Query suggestions are disabled by monkey patching graphql-core did_you_mean module.

Refs: HP-2351