### PR TITLE
fix: use getattr to access the original_error

### DIFF
--- a/open_city_profile/tests/test_graphql_api_validation_rules.py
+++ b/open_city_profile/tests/test_graphql_api_validation_rules.py
@@ -1,4 +1,5 @@
 from string import Template
+from unittest.mock import Mock
 
 import pytest
 from graphql import get_introspection_query
@@ -7,6 +8,7 @@ from open_city_profile.tests.graphql_test_helpers import (
     do_graphql_call,
     do_graphql_call_as_user,
 )
+from open_city_profile.views import GraphQLView
 from profiles.tests.factories import ProfileFactory
 
 
@@ -128,3 +130,12 @@ def test_trying_to_insert_nul_chars_errors_invalid_data_format(user_gql_client):
     executed = user_gql_client.execute(mutation)
     assert "postgres" not in executed["errors"][0]["message"].lower()
     assert executed["errors"][0]["message"] == "Invalid data format."
+
+
+def test_format_error_without_original_error_attribute():
+    mock_error = Mock(spec=[])
+    view = GraphQLView()
+
+    formatted_error = view.format_error(mock_error)
+
+    assert formatted_error["extensions"]["code"] == "GENERAL_ERROR"

--- a/open_city_profile/views.py
+++ b/open_city_profile/views.py
@@ -164,7 +164,8 @@ class GraphQLView(BaseGraphQLView):
     def format_error(error):
         formatted_error = super(GraphQLView, GraphQLView).format_error(error)
 
-        if isinstance(error.original_error, DataError):
+        original_error = getattr(error, "original_error", None)
+        if isinstance(original_error, DataError):
             formatted_error["message"] = "Invalid data format."
 
         if isinstance(formatted_error, dict):


### PR DESCRIPTION
GraphQlView's format_error is accessing to error's original_error. When the original_error is not present it caused the format_error itself to raise an error.
This add better handling for the original_error, using getattr, to avoid the above mentioned.

Refs HP-2485