### PR TITLE
fix: allow always allowed data fields regardless of service

### DIFF
--- a/profiles/models.py
+++ b/profiles/models.py
@@ -52,12 +52,13 @@ class AllowedDataFieldsMixin:
     check_allowed_data_fields = True
 
     @classmethod
-    def is_field_allowed_for_service(cls, field_name: str, service: Service):
-        if not service:
-            raise ValueError("No service identified")
-
+    def is_field_allowed_for_service(cls, field_name: str, service: Service = None):
+        # Always allow certain fields, regardless of the service
         if field_name in cls.always_allow_fields:
             return True
+
+        if not service:
+            return False
 
         allowed_data_fields = service.allowed_data_fields.values_list(
             "field_name", flat=True

--- a/profiles/tests/test_allowed_data_fields_mixin.py
+++ b/profiles/tests/test_allowed_data_fields_mixin.py
@@ -1,0 +1,43 @@
+import pytest
+
+from profiles.models import AllowedDataFieldsMixin, Profile
+from services.models import Service
+
+
+@pytest.mark.django_db
+def test_field_allowed_when_in_always_allow_fields(monkeypatch):
+    monkeypatch.setattr(AllowedDataFieldsMixin, "always_allow_fields", ["id"])
+    service = Service.objects.create(name="Test Service")
+
+    assert AllowedDataFieldsMixin.is_field_allowed_for_service("id", service) is True
+
+
+def test_field_allowed_when_service_is_none_and_in_always_allow_fields(monkeypatch):
+    monkeypatch.setattr(AllowedDataFieldsMixin, "always_allow_fields", ["id"])
+
+    assert AllowedDataFieldsMixin.is_field_allowed_for_service("id", None) is True
+
+
+def test_field_not_allowed_when_service_is_not_defined(monkeypatch):
+    monkeypatch.setattr(AllowedDataFieldsMixin, "always_allow_fields", [])
+
+    assert AllowedDataFieldsMixin.is_field_allowed_for_service("id", None) is False
+
+
+@pytest.mark.django_db
+def test_field_allowed_when_in_allowed_data_fields(monkeypatch):
+    monkeypatch.setattr(Profile, "always_allow_fields", [])
+    monkeypatch.setattr(Profile, "allowed_data_fields_map", {"id": ("id",)})
+    service = Service.objects.create(name="Test Service")
+    service.allowed_data_fields.create(field_name="id")
+
+    assert Profile.is_field_allowed_for_service("id", service) is True
+
+
+@pytest.mark.django_db
+def test_field_not_allowed_when_not_in_allowed_data_fields(monkeypatch):
+    monkeypatch.setattr(Profile, "always_allow_fields", [])
+    monkeypatch.setattr(Profile, "allowed_data_fields_map", {})
+    service = Service.objects.create(name="Test Service")
+
+    assert Profile.is_field_allowed_for_service("id", service) is False


### PR DESCRIPTION
Unfortunately, couldn't find a way to test this properly. Setting the service to None in the GQL client causes an error. However, somehow the unknown service warning can still trigger.

Refs: HP-2469