### PR TITLE
RATY-129 | Use DATABASE_PASSWORD env variable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: isort
         exclude: "migrations|snapshots"
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.10.0
+    rev: v9.18.0
     hooks:
       - id: commitlint
         stages: [commit-msg, manual]

--- a/open_city_profile/settings.py
+++ b/open_city_profile/settings.py
@@ -32,6 +32,7 @@ env = environ.Env(
         str,
         "postgres://open_city_profile:open_city_profile@localhost/open_city_profile",
     ),
+    DATABASE_PASSWORD=(str, ""),
     CACHE_URL=(str, "locmemcache://"),
     EMAIL_URL=(str, "consolemail://"),
     SENTRY_DSN=(str, ""),
@@ -135,6 +136,9 @@ if env("CSRF_TRUSTED_ORIGINS"):
 DATABASES = {"default": env.db()}
 # Ensure postgis engine
 DATABASES["default"]["ENGINE"] = "django.contrib.gis.db.backends.postgis"
+
+if env("DATABASE_PASSWORD"):
+    DATABASES["default"]["PASSWORD"] = env("DATABASE_PASSWORD")
 
 CACHES = {"default": env.cache()}
 vars().update(env.email_url())  # EMAIL_BACKEND etc.


### PR DESCRIPTION
This makes use of the DATABASE_PASSWORD env variable if it has been setupped.


Also bump commitlint to 9.18.0 to make it work with the .js config.



Refs RATY-129

