### PR TITLE
chore(entrypoint): use correct nc parameter

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ -z "$SKIP_DATABASE_CHECK" -o "$SKIP_DATABASE_CHECK" = "0" ]; then
-    until nc --verbose --wait 30 --send-only "$DATABASE_HOST" 5432
+    until nc --verbose --wait 30 -z "$DATABASE_HOST" 5432
     do
       echo "Waiting for postgres database connection..."
       sleep 1


### PR DESCRIPTION
use -z instead of --send-only since were not sending anything