### PR TITLE
HP-2530 | Include more information for profile's login methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
         name: ruff lint
       - id: ruff-format
         name: ruff format
-        args: [ --check ]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.19.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 default_stages: [pre-commit, manual]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -13,7 +13,7 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.8.0
     hooks:
       - id: ruff
         name: ruff lint
@@ -21,7 +21,7 @@ repos:
         name: ruff format
         args: [ --check ]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.18.0
+    rev: v9.19.0
     hooks:
       - id: commitlint
         stages: [commit-msg, manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        exclude: open_city_profile/static/open-city-profile/swagger/
       - id: check-yaml
       - id: check-toml
       - id: check-added-large-files
@@ -25,3 +26,7 @@ repos:
       - id: commitlint
         stages: [commit-msg, manual]
         additional_dependencies: ["@commitlint/config-conventional"]
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,10 @@ COPY --chown=appuser:appuser docker-entrypoint.sh /entrypoint/docker-entrypoint.
 ENTRYPOINT ["/entrypoint/docker-entrypoint.sh"]
 
 # ==============================
-FROM appbase as development
+FROM appbase AS development
 # ==============================
 
 RUN pip install --no-cache-dir -r /app/requirements-dev.txt
-
 
 ENV DEV_SERVER=1
 
@@ -41,7 +40,7 @@ USER appuser
 EXPOSE 8080/tcp
 
 # ==============================
-FROM appbase as staticbuilder
+FROM appbase AS staticbuilder
 # ==============================
 
 ENV VAR_ROOT /app
@@ -49,7 +48,7 @@ COPY --chown=appuser:appuser . /app
 RUN python manage.py collectstatic --noinput
 
 # ==============================
-FROM appbase as production
+FROM appbase AS production
 # ==============================
 
 COPY --from=staticbuilder --chown=appuser:appuser /app/static /app/static

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z "$SKIP_DATABASE_CHECK" -o "$SKIP_DATABASE_CHECK" = "0" ]; then
+if [ -z "$SKIP_DATABASE_CHECK" ] || [ "$SKIP_DATABASE_CHECK" = "0" ]; then
     until nc --verbose --wait 30 -z "$DATABASE_HOST" 5432
     do
       echo "Waiting for postgres database connection..."
@@ -35,7 +35,7 @@ if [[ "$CREATE_SUPERUSER" = "1" ]]; then
 fi
 
 # Start server
-if [[ ! -z "$@" ]]; then
+if [[ -n "$*" ]]; then
     "$@"
 elif [[ "$DEV_SERVER" = "1" ]]; then
     python ./manage.py runserver 0.0.0.0:8080

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,7 +38,7 @@ fi
 if [[ -n "$*" ]]; then
     "$@"
 elif [[ "$DEV_SERVER" = "1" ]]; then
-    python ./manage.py runserver 0.0.0.0:8080
+    python -Wd ./manage.py runserver 0.0.0.0:8080
 else
     uwsgi --ini .prod/uwsgi.ini
 fi

--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots['test_graphql_schema_matches_the_reference 1'] = '''type Query {
@@ -122,7 +123,8 @@ type ProfileNode implements Node {
   phones(offset: Int, before: String, after: String, first: Int, last: Int): PhoneNodeConnection
   addresses(offset: Int, before: String, after: String, first: Int, last: Int): AddressNodeConnection
   contactMethod: ContactMethod
-  loginMethods: [LoginMethodType]
+  loginMethods: [LoginMethodType] @deprecated(reason: "This field is deprecated, use availableLoginMethods.")
+  availableLoginMethods: [LoginMethodNode]
   sensitivedata: SensitiveDataNode
   serviceConnections(offset: Int, before: String, after: String, first: Int, last: Int): ServiceConnectionTypeConnection
   verifiedPersonalInformation: VerifiedPersonalInformationNode
@@ -220,6 +222,12 @@ enum LoginMethodType {
   PASSWORD
   OTP
   SUOMI_FI
+}
+
+type LoginMethodNode {
+  method: LoginMethodType!
+  createdAt: DateTime
+  userLabel: String
 }
 
 type SensitiveDataNode implements Node {

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -121,6 +121,7 @@ class Profile(UUIDModel, SerializableMixin, AllowedDataFieldsMixin):
         "language",
         "contact_method",
         "login_methods",
+        "available_login_methods",
     ]
 
     def resolve_profile(self):

--- a/profiles/tests/test_keycloak_integration.py
+++ b/profiles/tests/test_keycloak_integration.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,6 +9,37 @@ from profiles.keycloak_integration import (
     get_user_login_methods,
 )
 from utils.keycloak import UserNotFoundError
+
+RECOVERY_CODE_METHOD = {
+    "id": "ed913eb9-6243-45bb-b3f0-66eff3e9235e",
+    "type": "recovery-authn-codes",
+    "userLabel": "Recovery codes",
+    "createdDate": 1716894380239,
+    "credentialData": '{"hashIterations":1,"algorithm":"RS512","totalCodes":12,"remainingCodes":12}',
+}
+OTP_METHOD = {
+    "id": "d48ec74d-7c98-4810-b6ad-69022ce94bee",
+    "type": "otp",
+    "userLabel": "Phone",
+    "createdDate": 1716891252633,
+    "credentialData": '{"subType":"totp","digits":6,"counter":0,"period":30,"algorithm":"HmacSHA1"}',
+}
+PASSWORD_METHOD = {
+    "id": "b437745e-d17d-415c-a749-637833e87ff0",
+    "type": "password",
+    "createdDate": 1733399661491,
+    "credentialData": '{"hashIterations":100000,"algorithm":"pbkdf2-sha256","additionalParameters":{}}',
+}
+SUOMI_FI_PROVIDER = {
+    "identityProvider": "suomi_fi",
+    "userId": "e29a380628e06d3e0e903b8fb245f1910bceee063cda47c27df1f976dc60aa9b",
+    "userName": "e29a380628e06d3e0e903b8fb245f1910bceee063cda47c27df1f976dc60aa9b",
+}
+HELSINKI_AD_PROVIDER = {
+    "identityProvider": "helsinkiad",
+    "userId": "df6c34b9-22e6-49e7-8c2b-211c5267a84e",
+    "userName": "test@example.com",
+}
 
 
 @pytest.fixture
@@ -22,17 +54,17 @@ def test_get_user_identity_providers_no_client(monkeypatch):
     """Test the function when _keycloak_admin_client is None."""
     monkeypatch.setattr("profiles.keycloak_integration._keycloak_admin_client", None)
 
-    assert get_user_identity_providers("dummy_user_id") == set()
+    assert get_user_identity_providers("dummy_user_id") == []
 
 
 @pytest.mark.parametrize(
     "mock_return_value, expected_result",
     [
-        ([], set()),
-        ([{"identityProvider": "helsinkiad"}], {"helsinkiad"}),
+        ([], []),
+        ([HELSINKI_AD_PROVIDER], [{"method": "helsinkiad"}]),
         (
-            [{"identityProvider": "helsinkiad"}, {"identityProvider": "suomi_fi"}],
-            {"helsinkiad", "suomi_fi"},
+            [HELSINKI_AD_PROVIDER, SUOMI_FI_PROVIDER],
+            [{"method": "helsinkiad"}, {"method": "suomi_fi"}],
         ),
     ],
 )
@@ -52,14 +84,14 @@ def test_get_user_identity_providers_user_not_found(mock_keycloak_admin_client):
         UserNotFoundError
     )
 
-    assert get_user_identity_providers("dummy_user_id") == set()
+    assert get_user_identity_providers("dummy_user_id") == []
 
 
 def test_get_user_federated_identities_no_identities(mock_keycloak_admin_client):
     """Test the function when the user has no federated identities."""
     mock_keycloak_admin_client.get_user_federated_identities.return_value = set()
 
-    assert get_user_identity_providers("dummy_user_id") == set()
+    assert get_user_identity_providers("dummy_user_id") == []
 
 
 def test_get_user_identity_providers_exception(mock_keycloak_admin_client):
@@ -74,15 +106,44 @@ def test_get_user_identity_providers_exception(mock_keycloak_admin_client):
 def test_get_user_credential_types_no_client(monkeypatch):
     monkeypatch.setattr("profiles.keycloak_integration._keycloak_admin_client", None)
 
-    assert get_user_credential_types("dummy_user_id") == set()
+    assert get_user_credential_types("dummy_user_id") == []
 
 
 @pytest.mark.parametrize(
     "mock_return_value, expected_result",
     [
-        ([], set()),
-        ([{"type": "password"}], {"password"}),
-        ([{"type": "password"}, {"type": "otp"}], {"password", "otp"}),
+        ([], []),
+        (
+            [PASSWORD_METHOD],
+            [
+                {
+                    "created_at": datetime.datetime(
+                        2024, 12, 5, 11, 54, 21, 491000, tzinfo=datetime.UTC
+                    ),
+                    "method": "password",
+                    "user_label": None,
+                }
+            ],
+        ),
+        (
+            [PASSWORD_METHOD, OTP_METHOD],
+            [
+                {
+                    "created_at": datetime.datetime(
+                        2024, 12, 5, 11, 54, 21, 491000, tzinfo=datetime.UTC
+                    ),
+                    "method": "password",
+                    "user_label": None,
+                },
+                {
+                    "created_at": datetime.datetime(
+                        2024, 5, 28, 10, 14, 12, 633000, tzinfo=datetime.UTC
+                    ),
+                    "method": "otp",
+                    "user_label": "Phone",
+                },
+            ],
+        ),
     ],
 )
 def test_get_user_credential_types_with_data(
@@ -96,7 +157,7 @@ def test_get_user_credential_types_with_data(
 def test_get_user_credential_types_user_not_found(mock_keycloak_admin_client):
     mock_keycloak_admin_client.get_user_credentials.side_effect = UserNotFoundError
 
-    assert get_user_credential_types("dummy_user_id") == set()
+    assert get_user_credential_types("dummy_user_id") == []
 
 
 def test_get_user_credential_types_exception(mock_keycloak_admin_client):
@@ -108,13 +169,26 @@ def test_get_user_credential_types_exception(mock_keycloak_admin_client):
 
 # Tests for get_user_login_methods
 def test_get_user_login_methods(monkeypatch):
+    expected_credentials = [
+        {
+            "created_at": datetime.datetime(
+                2024, 12, 5, 11, 54, 21, 491000, tzinfo=datetime.UTC
+            ),
+            "method": "password",
+            "user_label": None,
+        },
+    ]
+    expected_idps = [{"method": "suomi_fi"}]
+
     monkeypatch.setattr(
         "profiles.keycloak_integration.get_user_credential_types",
-        lambda _: {"password"},
+        lambda _: expected_credentials,
     )
     monkeypatch.setattr(
         "profiles.keycloak_integration.get_user_identity_providers",
-        lambda _: {"provider1"},
+        lambda _: expected_idps,
     )
 
-    assert get_user_login_methods("dummy_user_id") == {"password", "provider1"}
+    assert (
+        get_user_login_methods("dummy_user_id") == expected_idps + expected_credentials
+    )


### PR DESCRIPTION
This PR adds additional information fields related to a Profile's login methods (authentication methods in keycloak). Since `ProfileNode.loginMethods` is already in use, a new `ProfileNode.availableLoginMethods` field is added and the former is deprecated.