### PR TITLE
fix: remove unsafe packages from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -65,8 +65,6 @@ django-sanitized-dump==1.2.2
     # via -r requirements.in
 django-searchable-encrypted-fields==0.2.1
     # via -r requirements.in
-ecdsa==0.19.0
-    # via python-jose
 executing==2.1.0
     # via stack-data
 graphene==3.3
@@ -123,10 +121,6 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyasn1==0.6.1
-    # via
-    #   python-jose
-    #   rsa
 pycparser==2.22
     # via cffi
 pycryptodome==3.20.0
@@ -149,8 +143,6 @@ requests==2.32.3
     #   requests-oauthlib
 requests-oauthlib==2.0.0
     # via -r requirements.in
-rsa==4.9
-    # via python-jose
 sentry-sdk==2.14.0
     # via -r requirements.in
 six==1.16.0
@@ -180,3 +172,8 @@ urllib3==2.2.3
     #   sentry-sdk
 wcwidth==0.2.13
     # via prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# ecdsa
+# pyasn1
+# rsa


### PR DESCRIPTION
Packages were accidentally added in a dependabot commit 81d25d7ff989f206ea340b2ef4e7a3925ca2c337