### PR TITLE
feat: add LoginMethodNode.credentialId field

### DIFF
--- a/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
+++ b/open_city_profile/tests/snapshots/snap_test_graphql_api_schema.py
@@ -228,6 +228,7 @@ type LoginMethodNode {
   method: LoginMethodType!
   createdAt: DateTime
   userLabel: String
+  credentialId: String
 }
 
 type SensitiveDataNode implements Node {

--- a/profiles/keycloak_integration.py
+++ b/profiles/keycloak_integration.py
@@ -132,6 +132,7 @@ def get_user_credential_types(user_id) -> list[dict]:
                 else None
             )
             credential = {
+                "credential_id": c["id"],
                 "method": c["type"],
                 "created_at": created_at,
                 "user_label": c.get("userLabel"),

--- a/profiles/schema.py
+++ b/profiles/schema.py
@@ -452,6 +452,9 @@ class LoginMethodNode(graphene.ObjectType):
     user_label = graphene.String(
         description="User-friendly label for the login method."
     )
+    credential_id = graphene.String(
+        description="Identifier for a credential type login method."
+    )
 
 
 class VerifiedPersonalInformationAddressNode(graphene.ObjectType):

--- a/profiles/tests/test_gql_my_profile_query.py
+++ b/profiles/tests/test_gql_my_profile_query.py
@@ -631,6 +631,7 @@ def test_user_can_see_own_login_methods_with_correct_amr_claim(
                 ),
                 "method": "password",
                 "user_label": None,
+                "credential_id": "93793c36-dd30-44c7-96b9-920c3b921f7c",
             },
         ],
     )
@@ -650,6 +651,7 @@ def test_user_can_see_own_login_methods_with_correct_amr_claim(
                     method
                     createdAt
                     userLabel
+                    credentialId
                 }
             }
         }
@@ -667,11 +669,13 @@ def test_user_can_see_own_login_methods_with_correct_amr_claim(
             "createdAt": None,
             "method": "SUOMI_FI",
             "userLabel": None,
+            "credentialId": None,
         },
         {
             "createdAt": "2024-12-05T11:54:21.491000+00:00",
             "method": "PASSWORD",
             "userLabel": None,
+            "credentialId": "93793c36-dd30-44c7-96b9-920c3b921f7c",
         },
     ]
 

--- a/profiles/tests/test_keycloak_integration.py
+++ b/profiles/tests/test_keycloak_integration.py
@@ -117,6 +117,7 @@ def test_get_user_credential_types_no_client(monkeypatch):
             [PASSWORD_METHOD],
             [
                 {
+                    "credential_id": PASSWORD_METHOD["id"],
                     "created_at": datetime.datetime(
                         2024, 12, 5, 11, 54, 21, 491000, tzinfo=datetime.UTC
                     ),
@@ -129,6 +130,7 @@ def test_get_user_credential_types_no_client(monkeypatch):
             [PASSWORD_METHOD, OTP_METHOD],
             [
                 {
+                    "credential_id": PASSWORD_METHOD["id"],
                     "created_at": datetime.datetime(
                         2024, 12, 5, 11, 54, 21, 491000, tzinfo=datetime.UTC
                     ),
@@ -136,6 +138,7 @@ def test_get_user_credential_types_no_client(monkeypatch):
                     "user_label": None,
                 },
                 {
+                    "credential_id": OTP_METHOD["id"],
                     "created_at": datetime.datetime(
                         2024, 5, 28, 10, 14, 12, 633000, tzinfo=datetime.UTC
                     ),


### PR DESCRIPTION
Identifier for the credentials is required for using keycloak's `delete_credential` action, which can be used to disable two factor authentication for a user.

Refs: HP-2716, HP-2717, HP-2727, HP-2725