### PR TITLE
feat: increase uWSGI buffer size

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -5,7 +5,7 @@ module = open_city_profile.wsgi
 static-map = /static=/app/static
 uid = nobody
 gid = nogroup
-buffer-size = 32768
+buffer-size = 65536
 master = 1
 processes = 2
 threads = 2


### PR DESCRIPTION
Allow users with huge API tokens to use the service.

Refs: HP-2895