### PR TITLE
chore: bump syrupy from 4.9.1 to 5.2.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -929,9 +929,9 @@ stack-data==0.6.3 \
     # via
     #   -r requirements.txt
     #   ipython
-syrupy==4.9.1 \
-    --hash=sha256:b7d0fcadad80a7d2f6c4c71917918e8ebe2483e8c703dfc8d49cdbb01081f9a4 \
-    --hash=sha256:b94cc12ed0e5e75b448255430af642516842a2374a46936dd2650cfb6dd20eda
+syrupy==5.2.0 \
+    --hash=sha256:0e6b7abf1e04f060f6c797bed8bca96f2468954168328041e02634a68fc11ff0 \
+    --hash=sha256:798cb493a6e20f4839e58ea8f10eb1b0d85684c676442f79786e219bf32618e6
     # via -r requirements-dev.in
 text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \


### PR DESCRIPTION
syrupy 4.9.1 has a pytest<=9.0.0 requirement, which in turn blocks dependabot's pytest version bump. Removed in 5.2.0 (which is >=2 weeks old).

Refs: HP-3078